### PR TITLE
[add] color extension 추가

### DIFF
--- a/BookTalk/BookTalk.xcodeproj/project.pbxproj
+++ b/BookTalk/BookTalk.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		AB22AD482C4E8D9F00C9A0F3 /* Base in Resources */ = {isa = PBXBuildFile; fileRef = AB22AD472C4E8D9F00C9A0F3 /* Base */; };
 		AB22AD512C4E92C100C9A0F3 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = AB22AD502C4E92C100C9A0F3 /* SnapKit */; };
 		AB22AD542C4E92C700C9A0F3 /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = AB22AD532C4E92C700C9A0F3 /* Then */; };
+		AB2E7BC72C5260E000CE43CB /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2E7BC62C5260E000CE43CB /* UIColor+.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -34,6 +35,7 @@
 		AB22AD442C4E8D9F00C9A0F3 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		AB22AD472C4E8D9F00C9A0F3 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		AB22AD492C4E8D9F00C9A0F3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		AB2E7BC62C5260E000CE43CB /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -54,6 +56,7 @@
 			children = (
 				057925372C4FF31D00834EC6 /* Application */,
 				057925442C4FF51400834EC6 /* Presentation */,
+				AB2E7BC22C5260A100CE43CB /* Util */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -113,6 +116,22 @@
 				057925172C4F927100834EC6 /* Sources */,
 			);
 			path = BookTalk;
+			sourceTree = "<group>";
+		};
+		AB2E7BC22C5260A100CE43CB /* Util */ = {
+			isa = PBXGroup;
+			children = (
+				AB2E7BC32C5260AB00CE43CB /* Extension */,
+			);
+			path = Util;
+			sourceTree = "<group>";
+		};
+		AB2E7BC32C5260AB00CE43CB /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+				AB2E7BC62C5260E000CE43CB /* UIColor+.swift */,
+			);
+			path = Extension;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -201,6 +220,7 @@
 				0579253F2C4FF4D700834EC6 /* OpenTalkViewController.swift in Sources */,
 				057925432C4FF4E100834EC6 /* MyViewController.swift in Sources */,
 				0579253B2C4FF4CA00834EC6 /* HomeViewController.swift in Sources */,
+				AB2E7BC72C5260E000CE43CB /* UIColor+.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/BookTalk/BookTalk/Sources/Util/Extension/UIColor+.swift
+++ b/BookTalk/BookTalk/Sources/Util/Extension/UIColor+.swift
@@ -1,0 +1,31 @@
+//
+//  UIColor+.swift
+//  BookTalk
+//
+//  Created by 김민 on 7/25/24.
+//
+
+import UIKit.UIColor
+
+extension UIColor {
+
+    convenience init(hex: UInt, alpha: Double = 1) {
+        self.init(
+            red: Double((hex >> 16) & 0xFF) / 255,
+            green: Double((hex >> 8) & 0xFF) / 255,
+            blue: Double(hex & 0xFF) / 255,
+            alpha: alpha
+        )
+    }
+}
+
+extension UIColor {
+
+    // MARK: Core
+
+    static let accentGreen: UIColor = .init(hex: 0x2B7746)
+
+    // MARK: Grayscale
+
+    static let gray100: UIColor = .init(hex: 0xDBDBDB)
+}


### PR DESCRIPTION
## 📚 PR 요약
color extension 추가

## 📝 작업 내용
color extension 추가
- rgb / hex로 초기화 가능하도록 설정
- 앱 키 컬러, gray100 추가

## 📌 참고 사항
필요한 컬러 있으시면 추가해서 사용하고, 피그마에도 같이 업데이트하면 좋겠습니다!


## 📮 관련 이슈
- Resolved: #9 
