### PR TITLE
[style] 네비게이션 바 타이틀 제거

### DIFF
--- a/BookTalk/BookTalk/Sources/Presentation/HomeScene/HomeViewController.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/HomeScene/HomeViewController.swift
@@ -7,8 +7,6 @@
 
 import UIKit
 
-import SafeAreaBrush
-
 class HomeViewController: UIViewController {
     
     override func viewDidLoad() {

--- a/BookTalk/BookTalk/Sources/Presentation/HomeScene/HomeViewController.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/HomeScene/HomeViewController.swift
@@ -20,8 +20,6 @@ class HomeViewController: UIViewController {
     
     @objc private func searchIconTapped() {
         let searchVC = SearchViewController()
-        
-        navigationItem.title = ""
         navigationController?.pushViewController(searchVC, animated: true)
     }
 }

--- a/BookTalk/BookTalk/Sources/Presentation/MainTabBarController.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/MainTabBarController.swift
@@ -79,6 +79,7 @@ class MainTabBarController: UITabBarController {
         let navigationController = UINavigationController(rootViewController: rootViewController)
         navigationController.tabBarItem = tabBarItem
         navigationController.navigationBar.tintColor = .black
+        navigationController.navigationBar.topItem?.title = ""
         
         return navigationController
     }


### PR DESCRIPTION
## 📚 PR 요약
내비게이션 바 타이틀 및 미사용 코드 제거

## 📝 작업 내용
- MainTabBarController에서 전역적으로 내비게이션 바 타이틀이 생성되지 않도록 설정
- HomeViewController에서 미사용 라이브러리 import 제거

## 📌 참고 사항


## 📷 Screenshot


## 📮 관련 이슈
- Resolved: #7 
