### PR TITLE
[feat] 책 상세 페이지 UI 구현

### DIFF
--- a/BookTalk/BookTalk.xcodeproj/project.pbxproj
+++ b/BookTalk/BookTalk.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		054543F92C5A24D000E64948 /* SearchCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 054543F82C5A24D000E64948 /* SearchCell.swift */; };
 		054544152C5AA80700E64948 /* BookInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 054544142C5AA80700E64948 /* BookInfo.swift */; };
 		054544232C5AAEFC00E64948 /* SearchHistoryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 054544222C5AAEFC00E64948 /* SearchHistoryCell.swift */; };
+		056F304E2C60D54500931302 /* BookDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 056F304D2C60D54500931302 /* BookDetailViewModel.swift */; };
 		057925392C4FF34A00834EC6 /* MainTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 057925382C4FF34A00834EC6 /* MainTabBarController.swift */; };
 		0579253B2C4FF4CA00834EC6 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0579253A2C4FF4CA00834EC6 /* HomeViewController.swift */; };
 		0579253F2C4FF4D700834EC6 /* OpenTalkViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0579253E2C4FF4D700834EC6 /* OpenTalkViewController.swift */; };
@@ -74,6 +75,7 @@
 		054543F82C5A24D000E64948 /* SearchCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchCell.swift; sourceTree = "<group>"; };
 		054544142C5AA80700E64948 /* BookInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookInfo.swift; sourceTree = "<group>"; };
 		054544222C5AAEFC00E64948 /* SearchHistoryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchHistoryCell.swift; sourceTree = "<group>"; };
+		056F304D2C60D54500931302 /* BookDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookDetailViewModel.swift; sourceTree = "<group>"; };
 		057925382C4FF34A00834EC6 /* MainTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarController.swift; sourceTree = "<group>"; };
 		0579253A2C4FF4CA00834EC6 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		0579253E2C4FF4D700834EC6 /* OpenTalkViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenTalkViewController.swift; sourceTree = "<group>"; };
@@ -269,6 +271,7 @@
 		056F30482C60D4F100931302 /* ViewModel */ = {
 			isa = PBXGroup;
 			children = (
+				056F304D2C60D54500931302 /* BookDetailViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -644,6 +647,7 @@
 				AB0C0F6A2C5BFDBE007812C5 /* ChatModel.swift in Sources */,
 				AB22AD3C2C4E8D9D00C9A0F3 /* AppDelegate.swift in Sources */,
 				AB2E7BE72C53D2A300CE43CB /* ShowAllBookCell.swift in Sources */,
+				056F304E2C60D54500931302 /* BookDetailViewModel.swift in Sources */,
 				054543A92C57531C00E64948 /* HomeHeaderView.swift in Sources */,
 				AB0C0F5F2C5BE285007812C5 /* OpenTalkPageType.swift in Sources */,
 				AB22AD3E2C4E8D9D00C9A0F3 /* SceneDelegate.swift in Sources */,

--- a/BookTalk/BookTalk.xcodeproj/project.pbxproj
+++ b/BookTalk/BookTalk.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		054544232C5AAEFC00E64948 /* SearchHistoryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 054544222C5AAEFC00E64948 /* SearchHistoryCell.swift */; };
 		056F304E2C60D54500931302 /* BookDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 056F304D2C60D54500931302 /* BookDetailViewModel.swift */; };
 		056F30502C60D57100931302 /* BookInfoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 056F304F2C60D57100931302 /* BookInfoCell.swift */; };
+		056F30522C60D5A100931302 /* NearbyCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 056F30512C60D5A100931302 /* NearbyCell.swift */; };
 		057925392C4FF34A00834EC6 /* MainTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 057925382C4FF34A00834EC6 /* MainTabBarController.swift */; };
 		0579253B2C4FF4CA00834EC6 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0579253A2C4FF4CA00834EC6 /* HomeViewController.swift */; };
 		0579253F2C4FF4D700834EC6 /* OpenTalkViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0579253E2C4FF4D700834EC6 /* OpenTalkViewController.swift */; };
@@ -78,6 +79,7 @@
 		054544222C5AAEFC00E64948 /* SearchHistoryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchHistoryCell.swift; sourceTree = "<group>"; };
 		056F304D2C60D54500931302 /* BookDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookDetailViewModel.swift; sourceTree = "<group>"; };
 		056F304F2C60D57100931302 /* BookInfoCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookInfoCell.swift; sourceTree = "<group>"; };
+		056F30512C60D5A100931302 /* NearbyCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NearbyCell.swift; sourceTree = "<group>"; };
 		057925382C4FF34A00834EC6 /* MainTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarController.swift; sourceTree = "<group>"; };
 		0579253A2C4FF4CA00834EC6 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		0579253E2C4FF4D700834EC6 /* OpenTalkViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenTalkViewController.swift; sourceTree = "<group>"; };
@@ -297,6 +299,7 @@
 			isa = PBXGroup;
 			children = (
 				056F304F2C60D57100931302 /* BookInfoCell.swift */,
+				056F30512C60D5A100931302 /* NearbyCell.swift */,
 			);
 			path = TableViewCell;
 			sourceTree = "<group>";
@@ -638,6 +641,7 @@
 			files = (
 				054543352C5374D900E64948 /* SearchViewController.swift in Sources */,
 				054543F92C5A24D000E64948 /* SearchCell.swift in Sources */,
+				056F30522C60D5A100931302 /* NearbyCell.swift in Sources */,
 				054544232C5AAEFC00E64948 /* SearchHistoryCell.swift in Sources */,
 				AB2E7BE52C53C97800CE43CB /* CategoryBookCell.swift in Sources */,
 				AB2E7BEA2C53D69600CE43CB /* BookImageCell.swift in Sources */,

--- a/BookTalk/BookTalk.xcodeproj/project.pbxproj
+++ b/BookTalk/BookTalk.xcodeproj/project.pbxproj
@@ -256,6 +256,45 @@
 			path = MainTab;
 			sourceTree = "<group>";
 		};
+		056F30472C60D4E400931302 /* BookDetail */ = {
+			isa = PBXGroup;
+			children = (
+				056F304A2C60D4F800931302 /* Cell */,
+				056F30492C60D4F600931302 /* View */,
+				056F30482C60D4F100931302 /* ViewModel */,
+			);
+			path = BookDetail;
+			sourceTree = "<group>";
+		};
+		056F30482C60D4F100931302 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		056F30492C60D4F600931302 /* View */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		056F304A2C60D4F800931302 /* Cell */ = {
+			isa = PBXGroup;
+			children = (
+				056F304C2C60D51100931302 /* TableViewCell */,
+			);
+			path = Cell;
+			sourceTree = "<group>";
+		};
+		056F304C2C60D51100931302 /* TableViewCell */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = TableViewCell;
+			sourceTree = "<group>";
+		};
 		057925172C4F927100834EC6 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
@@ -289,6 +328,7 @@
 			isa = PBXGroup;
 			children = (
 				056F2FEE2C5B4E3600931302 /* MainTab */,
+				056F30472C60D4E400931302 /* BookDetail */,
 				0545432E2C53725200E64948 /* Home */,
 				054543AA2C5786B000E64948 /* Search */,
 				ABD10DE62C516D26005F290E /* Category */,

--- a/BookTalk/BookTalk.xcodeproj/project.pbxproj
+++ b/BookTalk/BookTalk.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		056F304E2C60D54500931302 /* BookDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 056F304D2C60D54500931302 /* BookDetailViewModel.swift */; };
 		056F30502C60D57100931302 /* BookInfoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 056F304F2C60D57100931302 /* BookInfoCell.swift */; };
 		056F30522C60D5A100931302 /* NearbyCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 056F30512C60D5A100931302 /* NearbyCell.swift */; };
+		056F30542C60D5D400931302 /* BookDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 056F30532C60D5D400931302 /* BookDetailViewController.swift */; };
 		057925392C4FF34A00834EC6 /* MainTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 057925382C4FF34A00834EC6 /* MainTabBarController.swift */; };
 		0579253B2C4FF4CA00834EC6 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0579253A2C4FF4CA00834EC6 /* HomeViewController.swift */; };
 		0579253F2C4FF4D700834EC6 /* OpenTalkViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0579253E2C4FF4D700834EC6 /* OpenTalkViewController.swift */; };
@@ -80,6 +81,7 @@
 		056F304D2C60D54500931302 /* BookDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookDetailViewModel.swift; sourceTree = "<group>"; };
 		056F304F2C60D57100931302 /* BookInfoCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookInfoCell.swift; sourceTree = "<group>"; };
 		056F30512C60D5A100931302 /* NearbyCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NearbyCell.swift; sourceTree = "<group>"; };
+		056F30532C60D5D400931302 /* BookDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookDetailViewController.swift; sourceTree = "<group>"; };
 		057925382C4FF34A00834EC6 /* MainTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarController.swift; sourceTree = "<group>"; };
 		0579253A2C4FF4CA00834EC6 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		0579253E2C4FF4D700834EC6 /* OpenTalkViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenTalkViewController.swift; sourceTree = "<group>"; };
@@ -283,6 +285,7 @@
 		056F30492C60D4F600931302 /* View */ = {
 			isa = PBXGroup;
 			children = (
+				056F30532C60D5D400931302 /* BookDetailViewController.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -641,6 +644,7 @@
 			files = (
 				054543352C5374D900E64948 /* SearchViewController.swift in Sources */,
 				054543F92C5A24D000E64948 /* SearchCell.swift in Sources */,
+				056F30542C60D5D400931302 /* BookDetailViewController.swift in Sources */,
 				056F30522C60D5A100931302 /* NearbyCell.swift in Sources */,
 				054544232C5AAEFC00E64948 /* SearchHistoryCell.swift in Sources */,
 				AB2E7BE52C53C97800CE43CB /* CategoryBookCell.swift in Sources */,

--- a/BookTalk/BookTalk.xcodeproj/project.pbxproj
+++ b/BookTalk/BookTalk.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		054544152C5AA80700E64948 /* BookInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 054544142C5AA80700E64948 /* BookInfo.swift */; };
 		054544232C5AAEFC00E64948 /* SearchHistoryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 054544222C5AAEFC00E64948 /* SearchHistoryCell.swift */; };
 		056F304E2C60D54500931302 /* BookDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 056F304D2C60D54500931302 /* BookDetailViewModel.swift */; };
+		056F30502C60D57100931302 /* BookInfoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 056F304F2C60D57100931302 /* BookInfoCell.swift */; };
 		057925392C4FF34A00834EC6 /* MainTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 057925382C4FF34A00834EC6 /* MainTabBarController.swift */; };
 		0579253B2C4FF4CA00834EC6 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0579253A2C4FF4CA00834EC6 /* HomeViewController.swift */; };
 		0579253F2C4FF4D700834EC6 /* OpenTalkViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0579253E2C4FF4D700834EC6 /* OpenTalkViewController.swift */; };
@@ -76,6 +77,7 @@
 		054544142C5AA80700E64948 /* BookInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookInfo.swift; sourceTree = "<group>"; };
 		054544222C5AAEFC00E64948 /* SearchHistoryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchHistoryCell.swift; sourceTree = "<group>"; };
 		056F304D2C60D54500931302 /* BookDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookDetailViewModel.swift; sourceTree = "<group>"; };
+		056F304F2C60D57100931302 /* BookInfoCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookInfoCell.swift; sourceTree = "<group>"; };
 		057925382C4FF34A00834EC6 /* MainTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarController.swift; sourceTree = "<group>"; };
 		0579253A2C4FF4CA00834EC6 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		0579253E2C4FF4D700834EC6 /* OpenTalkViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenTalkViewController.swift; sourceTree = "<group>"; };
@@ -294,6 +296,7 @@
 		056F304C2C60D51100931302 /* TableViewCell */ = {
 			isa = PBXGroup;
 			children = (
+				056F304F2C60D57100931302 /* BookInfoCell.swift */,
 			);
 			path = TableViewCell;
 			sourceTree = "<group>";
@@ -660,6 +663,7 @@
 				AB2E7BDA2C53B3F300CE43CB /* SecondCategoryViewController.swift in Sources */,
 				057925392C4FF34A00834EC6 /* MainTabBarController.swift in Sources */,
 				AB0C0F6D2C5BFE5C007812C5 /* ChatViewModel.swift in Sources */,
+				056F30502C60D57100931302 /* BookInfoCell.swift in Sources */,
 				AB2E7BE12C53C16500CE43CB /* BannerCell.swift in Sources */,
 				AB0C0F592C5BD98B007812C5 /* OpenTalkPageCell.swift in Sources */,
 				054543A22C5751DD00E64948 /* SuggestionCell.swift in Sources */,

--- a/BookTalk/BookTalk/Sources/Model/HomeMockData.swift
+++ b/BookTalk/BookTalk/Sources/Model/HomeMockData.swift
@@ -11,151 +11,261 @@ struct HomeMockData {
     static let sections: [HomeSection] = [
         HomeSection(
             header: "현재 핫한 오픈톡",
-            basicBookInfo: [
-                BasicBookInfo(
-                    coverImageURL: "https://example.com/1.png",
-                    title: "Book 1",
-                    author: "Author 1"
+            bookInfo: [
+                DetailBookInfo(
+                    basicBookInfo: BasicBookInfo(
+                        coverImageURL: "https://example.com/1.png",
+                        title: "Book 1",
+                        author: "Author 1"
+                    ),
+                    publisher: "Publisher 1",
+                    publicationDate: "2024-01-01",
+                    isAvailable: true,
+                    isFavorite: false,
+                    distance: nil
                 ),
-                BasicBookInfo(
-                    coverImageURL: "https://example.com/2.png",
-                    title: "Book 2",
-                    author: "Author 2"
+                DetailBookInfo(
+                    basicBookInfo: BasicBookInfo(
+                        coverImageURL: "https://example.com/2.png",
+                        title: "Book 2",
+                        author: "Author 2"
+                    ),
+                    publisher: "Publisher 2",
+                    publicationDate: "2024-01-02",
+                    isAvailable: false,
+                    isFavorite: false,
+                    distance: nil
                 ),
-                BasicBookInfo(
-                    coverImageURL: "https://example.com/3.png",
-                    title: "Book 3",
-                    author: "Author 3"
+                DetailBookInfo(
+                    basicBookInfo: BasicBookInfo(
+                        coverImageURL: "https://example.com/3.png",
+                        title: "Book 3",
+                        author: "Author 3"
+                    ),
+                    publisher: "Publisher 3",
+                    publicationDate: "2024-01-03",
+                    isAvailable: true,
+                    isFavorite: false,
+                    distance: nil
                 ),
-                BasicBookInfo(
-                    coverImageURL: "https://example.com/4.png",
-                    title: "Book 4",
-                    author: "Author 4"
+                DetailBookInfo(
+                    basicBookInfo: BasicBookInfo(
+                        coverImageURL: "https://example.com/4.png",
+                        title: "Book 4",
+                        author: "Author 4"
+                    ),
+                    publisher: "Publisher 4",
+                    publicationDate: "2024-01-04",
+                    isAvailable: true,
+                    isFavorite: false,
+                    distance: nil
                 ),
-                BasicBookInfo(
-                    coverImageURL: "https://example.com/5.png",
-                    title: "Book 5",
-                    author: "Author 5"
+                DetailBookInfo(
+                    basicBookInfo: BasicBookInfo(
+                        coverImageURL: "https://example.com/5.png",
+                        title: "Book 5",
+                        author: "Author 5"
+                    ),
+                    publisher: "Publisher 5",
+                    publicationDate: "2024-01-05",
+                    isAvailable: false,
+                    isFavorite: false,
+                    distance: nil
                 )
             ]
         ),
         HomeSection(
-            header: "이번 달 20대 남성이 많이 대출한 책!",
-            basicBookInfo: [
-                BasicBookInfo(
-                    coverImageURL: "https://example.com/1-1.png",
-                    title: "Book 1-1",
-                    author: "Author 1-1"
+            header: "이번 달 북토크가 추천드리는 책!",
+            bookInfo: [
+                DetailBookInfo(
+                    basicBookInfo: BasicBookInfo(
+                        coverImageURL: "https://example.com/1-1.png",
+                        title: "Book 1-1",
+                        author: "Author 1-1"
+                    ),
+                    publisher: "Publisher 1-1",
+                    publicationDate: "2024-01-01",
+                    isAvailable: true,
+                    isFavorite: false,
+                    distance: nil
                 ),
-                BasicBookInfo(
-                    coverImageURL: "https://example.com/2-1.png",
-                    title: "Book 2-1",
-                    author: "Author 2-1"
+                DetailBookInfo(
+                    basicBookInfo: BasicBookInfo(
+                        coverImageURL: "https://example.com/2-1.png",
+                        title: "Book 2-1",
+                        author: "Author 2-1"
+                    ),
+                    publisher: "Publisher 2-1",
+                    publicationDate: "2024-01-02",
+                    isAvailable: false,
+                    isFavorite: false,
+                    distance: nil
                 ),
-                BasicBookInfo(
-                    coverImageURL: "https://example.com/3-1.png",
-                    title: "Book 3-1",
-                    author: "Author 3-1"
+                DetailBookInfo(
+                    basicBookInfo: BasicBookInfo(
+                        coverImageURL: "https://example.com/3-1.png",
+                        title: "Book 3-1",
+                        author: "Author 3-1"
+                    ),
+                    publisher: "Publisher 3-1",
+                    publicationDate: "2024-01-03",
+                    isAvailable: true,
+                    isFavorite: false,
+                    distance: nil
                 ),
-                BasicBookInfo(
-                    coverImageURL: "https://example.com/4-1.png",
-                    title: "Book 4-1",
-                    author: "Author 4-1"
+                DetailBookInfo(
+                    basicBookInfo: BasicBookInfo(
+                        coverImageURL: "https://example.com/4-1.png",
+                        title: "Book 4-1",
+                        author: "Author 4-1"
+                    ),
+                    publisher: "Publisher 4-1",
+                    publicationDate: "2024-01-04",
+                    isAvailable: true,
+                    isFavorite: false,
+                    distance: nil
                 ),
-                BasicBookInfo(
-                    coverImageURL: "https://example.com/5-1.png",
-                    title: "Book 5-1",
-                    author: "Author 5-1"
+                DetailBookInfo(
+                    basicBookInfo: BasicBookInfo(
+                        coverImageURL: "https://example.com/5-1.png",
+                        title: "Book 5-1",
+                        author: "Author 5-1"
+                    ),
+                    publisher: "Publisher 5-1",
+                    publicationDate: "2024-01-05",
+                    isAvailable: false,
+                    isFavorite: false,
+                    distance: nil
                 )
             ]
         ),
         HomeSection(
-            header: "인간관계론을 읽은 OOO님, 이 책은 어떠세요?",
-            basicBookInfo: [
-                BasicBookInfo(
-                    coverImageURL: "https://example.com/1-2.png",
-                    title: "Book 1-2",
-                    author: "Author 1-2"
+            header: "OOO님 주변에서 대출이 많은 도서!",
+            bookInfo: [
+                DetailBookInfo(
+                    basicBookInfo: BasicBookInfo(
+                        coverImageURL: "https://example.com/1-2.png",
+                        title: "Book 1-2",
+                        author: "Author 1-2"
+                    ),
+                    publisher: "Publisher 1-2",
+                    publicationDate: "2024-01-01",
+                    isAvailable: true,
+                    isFavorite: false,
+                    distance: nil
                 ),
-                BasicBookInfo(
-                    coverImageURL: "https://example.com/2-2.png",
-                    title: "Book 2-2",
-                    author: "Author 2-2"
+                DetailBookInfo(
+                    basicBookInfo: BasicBookInfo(
+                        coverImageURL: "https://example.com/2-2.png",
+                        title: "Book 2-2",
+                        author: "Author 2-2"
+                    ),
+                    publisher: "Publisher 2-2",
+                    publicationDate: "2024-01-02",
+                    isAvailable: false,
+                    isFavorite: false,
+                    distance: nil
                 ),
-                BasicBookInfo(
-                    coverImageURL: "https://example.com/3-2.png",
-                    title: "Book 3-2",
-                    author: "Author 3-2"
+                DetailBookInfo(
+                    basicBookInfo: BasicBookInfo(
+                        coverImageURL: "https://example.com/3-2.png",
+                        title: "Book 3-2",
+                        author: "Author 3-2"
+                    ),
+                    publisher: "Publisher 3-2",
+                    publicationDate: "2024-01-03",
+                    isAvailable: true,
+                    isFavorite: false,
+                    distance: nil
                 ),
-                BasicBookInfo(
-                    coverImageURL: "https://example.com/4-2.png",
-                    title: "Book 4-2",
-                    author: "Author 4-2"
+                DetailBookInfo(
+                    basicBookInfo: BasicBookInfo(
+                        coverImageURL: "https://example.com/4-2.png",
+                        title: "Book 4-2",
+                        author: "Author 4-2"
+                    ),
+                    publisher: "Publisher 4-2",
+                    publicationDate: "2024-01-04",
+                    isAvailable: true,
+                    isFavorite: false,
+                    distance: nil
                 ),
-                BasicBookInfo(
-                    coverImageURL: "https://example.com/5-2.png",
-                    title: "Book 5-2",
-                    author: "Author 5-2"
-                )
-            ]
-        ),
-        HomeSection(
-            header: "OOO님 동네에서 대출이 많은 도서!",
-            basicBookInfo: [
-                BasicBookInfo(
-                    coverImageURL: "https://example.com/1-3.png",
-                    title: "Book 1-3",
-                    author: "Author 1-3"
-                ),
-                BasicBookInfo(
-                    coverImageURL: "https://example.com/2-3.png",
-                    title: "Book 2-3",
-                    author: "Author 2-3"
-                ),
-                BasicBookInfo(
-                    coverImageURL: "https://example.com/3-3.png",
-                    title: "Book 3-3",
-                    author: "Author 3-3"
-                ),
-                BasicBookInfo(
-                    coverImageURL: "https://example.com/4-3.png",
-                    title: "Book 4-3",
-                    author: "Author 4-3"
-                ),
-                BasicBookInfo(
-                    coverImageURL: "https://example.com/5-3.png",
-                    title: "Book 5-3",
-                    author: "Author 5-3"
+                DetailBookInfo(
+                    basicBookInfo: BasicBookInfo(
+                        coverImageURL: "https://example.com/5-2.png",
+                        title: "Book 5-2",
+                        author: "Author 5-2"
+                    ),
+                    publisher: "Publisher 5-2",
+                    publicationDate: "2024-01-05",
+                    isAvailable: false,
+                    isFavorite: false,
+                    distance: nil
                 )
             ]
         ),
         HomeSection(
             header: "대출 급상승 도서!",
-            basicBookInfo: [
-                BasicBookInfo(
-                    coverImageURL: "https://example.com/1-4.png",
-                    title: "Book 1-4",
-                    author: "Author 1-4"
+            bookInfo: [
+                DetailBookInfo(
+                    basicBookInfo: BasicBookInfo(
+                        coverImageURL: "https://example.com/1-3.png",
+                        title: "Book 1-3",
+                        author: "Author 1-3"
+                    ),
+                    publisher: "Publisher 1-3",
+                    publicationDate: "2024-01-01",
+                    isAvailable: true,
+                    isFavorite: false,
+                    distance: nil
                 ),
-                BasicBookInfo(
-                    coverImageURL: "https://example.com/2-4.png",
-                    title: "Book 2-4",
-                    author: "Author 2-4"
+                DetailBookInfo(
+                    basicBookInfo: BasicBookInfo(
+                        coverImageURL: "https://example.com/2-3.png",
+                        title: "Book 2-3",
+                        author: "Author 2-3"
+                    ),
+                    publisher: "Publisher 2-3",
+                    publicationDate: "2024-01-02",
+                    isAvailable: false,
+                    isFavorite: false,
+                    distance: nil
                 ),
-                BasicBookInfo(
-                    coverImageURL: "https://example.com/3-4.png",
-                    title: "Book 3-4",
-                    author: "Author 3-4"
+                DetailBookInfo(
+                    basicBookInfo: BasicBookInfo(
+                        coverImageURL: "https://example.com/3-3.png",
+                        title: "Book 3-3",
+                        author: "Author 3-3"
+                    ),
+                    publisher: "Publisher 3-3",
+                    publicationDate: "2024-01-03",
+                    isAvailable: true,
+                    isFavorite: false,
+                    distance: nil
                 ),
-                BasicBookInfo(
-                    coverImageURL: "https://example.com/4-4.png",
-                    title: "Book 4-4",
-                    author: "Author 4-4"
+                DetailBookInfo(
+                    basicBookInfo: BasicBookInfo(
+                        coverImageURL: "https://example.com/4-3.png",
+                        title: "Book 4-3",
+                        author: "Author 4-3"
+                    ),
+                    publisher: "Publisher 4-3",
+                    publicationDate: "2024-01-04",
+                    isAvailable: true,
+                    isFavorite: false,
+                    distance: nil
                 ),
-                BasicBookInfo(
-                    coverImageURL: "https://example.com/5-4.png",
-                    title: "Book 5-4",
-                    author: "Author 5-4"
+                DetailBookInfo(
+                    basicBookInfo: BasicBookInfo(
+                        coverImageURL: "https://example.com/5-3.png",
+                        title: "Book 5-3",
+                        author: "Author 5-3"
+                    ),
+                    publisher: "Publisher 5-3",
+                    publicationDate: "2024-01-05",
+                    isAvailable: false,
+                    isFavorite: false,
+                    distance: nil
                 )
             ]
         )

--- a/BookTalk/BookTalk/Sources/Model/HomeSection.swift
+++ b/BookTalk/BookTalk/Sources/Model/HomeSection.swift
@@ -9,5 +9,5 @@ import Foundation
 
 struct HomeSection {
     let header: String
-    let basicBookInfo: [BasicBookInfo]
+    let bookInfo: [DetailBookInfo]
 }

--- a/BookTalk/BookTalk/Sources/Presentation/BookDetail/Cell/TableViewCell/BookInfoCell.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/BookDetail/Cell/TableViewCell/BookInfoCell.swift
@@ -1,0 +1,140 @@
+//
+//  BookInfoCell.swift
+//  BookTalk
+//
+//  Created by RAFA on 8/5/24.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class BookInfoCell: UITableViewCell {
+    
+    // MARK: - Properties
+    
+    private let bookImageView = UIImageView()
+    private let titleLabel = UILabel()
+    private let authorLabel = UILabel()
+    private let publisherLabel = UILabel()
+    private let publicationDateLabel = UILabel()
+    private let availabilityLabel = UILabel()
+    private let bookInfoStackView = UIStackView()
+    private let joinOpenTalkButton = UIButton(type: .system)
+    
+    // MARK: - Lifecycle
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setViews()
+        setConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Helpers
+    
+    func bind( _ viewModel: BookDetailViewModel) {
+        bookImageView.image = UIImage(named: "\(viewModel.coverImageURL)")
+        titleLabel.text = viewModel.title
+        authorLabel.text = viewModel.author
+        publisherLabel.text = viewModel.publisher
+        publicationDateLabel.text = viewModel.publicationDate
+        availabilityLabel.text = viewModel.availabilityText
+        availabilityLabel.textColor = viewModel.availabilityTextColor
+    }
+    
+    // MARK: - Set UI
+    
+    private func setViews() {
+        bookImageView.do {
+            $0.contentMode = .scaleAspectFit
+            $0.backgroundColor = .gray100
+        }
+        
+        titleLabel.do {
+            $0.textColor = .black
+            $0.textAlignment = .left
+            $0.font = .systemFont(ofSize: 25, weight: .bold)
+        }
+        
+        authorLabel.do {
+            $0.textColor = .black
+            $0.textAlignment = .left
+            $0.font = .systemFont(ofSize: 15, weight: .medium)
+        }
+        
+        publisherLabel.do {
+            $0.textColor = .black
+            $0.textAlignment = .left
+            $0.font = .systemFont(ofSize: 15, weight: .medium)
+        }
+        
+        publicationDateLabel.do {
+            $0.textColor = .black
+            $0.textAlignment = .left
+            $0.font = .systemFont(ofSize: 15, weight: .medium)
+        }
+        
+        availabilityLabel.do {
+            $0.textColor = .black
+            $0.textAlignment = .left
+            $0.font = .systemFont(ofSize: 15, weight: .semibold)
+        }
+        
+        bookInfoStackView.do {
+            $0.addArrangedSubview(authorLabel)
+            $0.addArrangedSubview(publisherLabel)
+            $0.addArrangedSubview(publicationDateLabel)
+            $0.addArrangedSubview(availabilityLabel)
+            $0.axis = .vertical
+            $0.alignment = .fill
+            $0.distribution = .fillProportionally
+            $0.spacing = 5
+        }
+        
+        joinOpenTalkButton.do {
+            $0.backgroundColor = .accentOrange
+            $0.clipsToBounds = true
+            $0.layer.cornerRadius = 10
+            $0.setTitle("오픈톡 참여하기", for: .normal)
+            $0.setTitleColor(.white, for: .normal)
+            $0.titleLabel?.font = .systemFont(ofSize: 17, weight: .bold)
+        }
+    }
+    
+    private func setConstraints() {
+        [bookImageView, titleLabel, bookInfoStackView, joinOpenTalkButton].forEach {
+            contentView.addSubview($0)
+        }
+        
+        bookImageView.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.top.equalTo(contentView.safeAreaLayoutGuide.snp.top).offset(15)
+            $0.left.equalTo(15)
+            $0.height.equalTo(250)
+        }
+        
+        titleLabel.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.top.equalTo(bookImageView.snp.bottom).offset(10)
+            $0.left.equalTo(bookImageView)
+        }
+        
+        bookInfoStackView.snp.makeConstraints {
+            $0.centerX.left.equalTo(titleLabel)
+            $0.top.equalTo(titleLabel.snp.bottom).offset(10)
+        }
+        
+        joinOpenTalkButton.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.top.equalTo(bookInfoStackView.snp.bottom).offset(15)
+            $0.left.equalTo(bookInfoStackView)
+            $0.bottom.equalToSuperview().offset(-15)
+            $0.height.equalTo(50)
+        }
+    }
+}

--- a/BookTalk/BookTalk/Sources/Presentation/BookDetail/Cell/TableViewCell/NearbyCell.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/BookDetail/Cell/TableViewCell/NearbyCell.swift
@@ -1,0 +1,78 @@
+//
+//  NearbyCell.swift
+//  BookTalk
+//
+//  Created by RAFA on 8/5/24.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class NearbyCell: UITableViewCell {
+    
+    // MARK: - Properties
+    
+    private let titleLabel = UILabel()
+    private let mapView = UIView()
+    private let distanceLabel = UILabel()
+    private let nearbyInfoStackView = UIStackView()
+    
+    // MARK: - Lifecycle
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setViews()
+        setConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Set UI
+    
+    private func setViews() {
+        titleLabel.do {
+            $0.text = "대출 가능한 주변 도서관"
+            $0.textColor = .black
+            $0.textAlignment = .left
+            $0.font = .systemFont(ofSize: 25, weight: .bold)
+        }
+        
+        mapView.do {
+            $0.backgroundColor = .gray100
+        }
+        
+        distanceLabel.do {
+            $0.text = "성메 작은도서관 : 295m\n성산글마루 작은도서관 : 641m"
+            $0.textColor = .black
+            $0.textAlignment = .left
+            $0.numberOfLines = 0
+            $0.font = .systemFont(ofSize: 15, weight: .medium)
+        }
+        
+        nearbyInfoStackView.do {
+            $0.addArrangedSubview(titleLabel)
+            $0.addArrangedSubview(mapView)
+            $0.addArrangedSubview(distanceLabel)
+            $0.axis = .vertical
+            $0.alignment = .fill
+            $0.distribution = .fill
+            $0.spacing = 10
+        }
+    }
+    
+    private func setConstraints() {
+        contentView.addSubview(nearbyInfoStackView)
+        
+        mapView.snp.makeConstraints {
+            $0.height.equalTo(mapView.snp.width)
+        }
+        
+        nearbyInfoStackView.snp.makeConstraints {
+            $0.edges.equalToSuperview().inset(15)
+        }
+    }
+}

--- a/BookTalk/BookTalk/Sources/Presentation/BookDetail/View/BookDetailViewController.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/BookDetail/View/BookDetailViewController.swift
@@ -1,0 +1,256 @@
+//
+//  BookDetailViewController.swift
+//  BookTalk
+//
+//  Created by RAFA on 8/5/24.
+//
+
+import UIKit
+
+final class BookDetailViewController: BaseViewController {
+    
+    // MARK: - Properties
+    
+    var viewModel: BookDetailViewModel!
+    
+    private var favoriteButton = UIBarButtonItem()
+    private let floatingButton = UIButton(type: .system)
+    private let likeButton = UIButton(type: .system)
+    private let dislikeButton = UIButton(type: .system)
+    
+    private let tableView = UITableView(frame: .zero, style: .plain)
+    
+    // MARK: - Lifecycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        bind()
+    }
+    
+    // MARK: - Actions
+    
+    @objc private func handleFavoriteButton() {
+        viewModel.favoriteButtonDidTap()
+    }
+    
+    @objc private func floatingButtonDidTap() {
+        viewModel.toggleFloatingButton()
+    }
+    
+    @objc private func handleLikeButton() {
+        viewModel.likeButtonDidTap()
+    }
+    
+    @objc private func handleDislikeButton() {
+        viewModel.dislikeButtonDidTap()
+    }
+    
+    @objc private func handleBookmarkButton() {
+        viewModel.bookmarkButtonDidTap()
+    }
+    
+    // MARK: - Button Animations
+    
+    private func updateChildButtonVisibility() {
+        let buttons: [UIButton] = [likeButton, dislikeButton]
+        if viewModel.areChildButtonsVisible {
+            buttons.forEach { button in
+                button.layer.transform = CATransform3DMakeScale(0.4, 0.4, 1)
+                UIView.animate(
+                    withDuration: 0.3,
+                    delay: 0.2,
+                    usingSpringWithDamping: 0.55,
+                    initialSpringVelocity: 0.3,
+                    options: [.curveEaseInOut],
+                    animations: {
+                        button.layer.transform = CATransform3DIdentity
+                        button.alpha = 1.0
+                    }
+                )
+            }
+        } else {
+            UIView.animate(withDuration: 0.15, delay: 0.2) {
+                buttons.forEach { button in
+                    button.layer.transform = CATransform3DMakeScale(0.4, 0.4, 0.1)
+                    button.alpha = 0.0
+                }
+            }
+        }
+        rotateFloatingButton()
+    }
+    
+    private func rotateFloatingButton() {
+        let animation = CABasicAnimation(keyPath: "transform.rotation.z")
+        let fromValue = viewModel.areChildButtonsVisible ? 0 : CGFloat.pi / 4
+        let toValue = viewModel.areChildButtonsVisible ? CGFloat.pi / 4 : 0
+        animation.fromValue = fromValue
+        animation.toValue = toValue
+        animation.duration = 0.3
+        animation.fillMode = .forwards
+        animation.isRemovedOnCompletion = false
+        floatingButton.layer.add(animation, forKey: nil)
+    }
+    
+    // MARK: - Helpers
+    
+    private func bind() {
+        viewModel.onFavoriteButtonTapped = { [weak self] in
+            self?.updateFavoriteButtonState()
+        }
+        
+        viewModel.onFloatingButtonTapped = { [weak self] in
+            self?.updateChildButtonVisibility()
+        }
+        
+        viewModel.onLikeButtonTapped = { [weak self] in
+            self?.updateLikeButtonState()
+            self?.updateDislikeButtonState()
+        }
+        
+        viewModel.onDislikeButtonTapped = { [weak self] in
+            self?.updateDislikeButtonState()
+            self?.updateLikeButtonState()
+        }
+    }
+    
+    private func updateFavoriteButtonState() {
+        let imageName = viewModel.isFavorite ? "heart.fill" : "heart"
+        favoriteButton.image = UIImage(systemName: imageName)
+        
+        let tintColor: UIColor = viewModel.isFavorite ? .systemRed : .black
+        favoriteButton.tintColor = tintColor
+    }
+    
+    private func updateLikeButtonState() {
+        let imageName = viewModel.isLiked ? "hand.thumbsup.fill" : "hand.thumbsup"
+        likeButton.setImage(UIImage(systemName: imageName), for: .normal)
+    }
+    
+    private func updateDislikeButtonState() {
+        let imageName = viewModel.isDisliked ? "hand.thumbsdown.fill" : "hand.thumbsdown"
+        dislikeButton.setImage(UIImage(systemName: imageName), for: .normal)
+    }
+    
+    // MARK: - UI Setup
+    
+    override func setNavigationBar() {
+        favoriteButton = UIBarButtonItem(
+            image: UIImage(systemName: "heart"),
+            style: .plain,
+            target: self,
+            action: #selector(handleFavoriteButton)
+        )
+        
+        navigationItem.rightBarButtonItem = favoriteButton
+    }
+    
+    override func setViews() {
+        view.backgroundColor = .white
+        
+        tableView.do {
+            $0.dataSource = self
+            $0.separatorInset = .zero
+            $0.register(BookInfoCell.self, forCellReuseIdentifier: "BookInfoCell")
+            $0.register(NearbyCell.self, forCellReuseIdentifier: "NearbyCell")
+        }
+        
+        floatingButton.do {
+            var config = UIButton.Configuration.filled()
+            config.baseBackgroundColor = .accentOrange
+            config.cornerStyle = .capsule
+            config.image = UIImage(systemName: "plus")?
+                .withConfiguration(UIImage.SymbolConfiguration(pointSize: 20, weight: .medium))
+            $0.configuration = config
+            $0.layer.shadowRadius = 10
+            $0.layer.shadowOpacity = 0.3
+            $0.addTarget(self, action: #selector(floatingButtonDidTap), for: .touchUpInside)
+        }
+        
+        [likeButton, dislikeButton].forEach {
+            var config = UIButton.Configuration.filled()
+            config.cornerStyle = .capsule
+            $0.configuration = config
+            $0.layer.shadowRadius = 10
+            $0.layer.shadowOpacity = 0.3
+            $0.alpha = 0.0
+        }
+        
+        likeButton.do {
+            $0.configuration?.baseBackgroundColor = .systemBlue
+            $0.setImage(UIImage(systemName: "hand.thumbsup"), for: .normal)
+            $0.addTarget(self, action: #selector(handleLikeButton), for: .touchUpInside)
+        }
+
+        dislikeButton.do {
+            $0.configuration?.baseBackgroundColor = .systemRed
+            $0.setImage(UIImage(systemName: "hand.thumbsdown"), for: .normal)
+            $0.addTarget(self, action: #selector(handleDislikeButton), for: .touchUpInside)
+        }
+    }
+    
+    override func setConstraints() {
+        [tableView,
+         floatingButton,
+         likeButton,
+         dislikeButton].forEach { view.addSubview($0) }
+        
+        tableView.snp.makeConstraints {
+            $0.centerX.left.bottom.equalToSuperview()
+            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top)
+        }
+        
+        floatingButton.snp.makeConstraints {
+            $0.width.height.equalTo(60)
+            $0.right.equalToSuperview().inset(15)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).offset(-15)
+        }
+        
+        likeButton.snp.makeConstraints {
+            $0.width.height.equalTo(50)
+            $0.right.equalTo(floatingButton.snp.left).offset(-10)
+            $0.centerY.equalTo(floatingButton).offset(-15)
+        }
+
+        dislikeButton.snp.makeConstraints {
+            $0.width.height.equalTo(50)
+            $0.centerX.equalTo(floatingButton).offset(-15)
+            $0.bottom.equalTo(floatingButton.snp.top).offset(-10)
+        }
+    }
+}
+
+// MARK: - UITableViewDataSource
+
+extension BookDetailViewController: UITableViewDataSource {
+    
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return 2
+    }
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 1
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        if indexPath.section == 0 {
+            guard let cell = tableView.dequeueReusableCell(
+                withIdentifier: "BookInfoCell",
+                for: indexPath
+            ) as? BookInfoCell else {
+                return UITableViewCell()
+            }
+            cell.selectionStyle = .none
+            cell.bind(viewModel)
+            return cell
+        } else {
+            guard let cell = tableView.dequeueReusableCell(
+                withIdentifier: "NearbyCell",
+                for: indexPath
+            ) as? NearbyCell else {
+                return UITableViewCell()
+            }
+            cell.selectionStyle = .none
+            return cell
+        }
+    }
+}

--- a/BookTalk/BookTalk/Sources/Presentation/BookDetail/ViewModel/BookDetailViewModel.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/BookDetail/ViewModel/BookDetailViewModel.swift
@@ -1,0 +1,88 @@
+//
+//  BookDetailViewModel.swift
+//  BookTalk
+//
+//  Created by RAFA on 8/5/24.
+//
+
+import UIKit
+
+final class BookDetailViewModel {
+    
+    private let bookInfo: DetailBookInfo
+    
+    var coverImageURL: String {
+        return bookInfo.basicBookInfo.coverImageURL
+    }
+    
+    var title: String {
+        return bookInfo.basicBookInfo.title
+    }
+        
+    var author: String {
+        return bookInfo.basicBookInfo.author
+    }
+    
+    var publisher: String {
+        return bookInfo.publisher
+    }
+    
+    var publicationDate: String {
+        return bookInfo.publicationDate
+    }
+    
+    var availabilityText: String {
+        return bookInfo.isAvailable ? "대출 가능" : "대출 불가능"
+    }
+    
+    var availabilityTextColor: UIColor {
+        return bookInfo.isAvailable ? .systemGreen : .systemRed
+    }
+    
+    var distanceText: String {
+        return "\(bookInfo.distance ?? 0.0)미터"
+    }
+    
+    private(set) var isFavorite: Bool = false
+    private(set) var isLiked: Bool = false
+    private(set) var isDisliked: Bool = false
+    private(set) var isBookmarked: Bool = false
+
+    var onFavoriteButtonTapped: (() -> Void)?
+    var onFloatingButtonTapped: (() -> Void)?
+    var onLikeButtonTapped: (() -> Void)?
+    var onDislikeButtonTapped: (() -> Void)?
+    var onBookmarkButtonTapped: (() -> Void)?
+    var areChildButtonsVisible: Bool = false
+    
+    init(bookInfo: DetailBookInfo) {
+        self.bookInfo = bookInfo
+    }
+    
+    func favoriteButtonDidTap() {
+        isFavorite.toggle()
+        onFavoriteButtonTapped?()
+    }
+    
+    func toggleFloatingButton() {
+        areChildButtonsVisible.toggle()
+        onFloatingButtonTapped?()
+    }
+    
+    func likeButtonDidTap() {
+        isLiked.toggle()
+        if isLiked { isDisliked = false }
+        onLikeButtonTapped?()
+    }
+    
+    func dislikeButtonDidTap() {
+        isDisliked.toggle()
+        if isDisliked { isLiked = false }
+        onDislikeButtonTapped?()
+    }
+    
+    func bookmarkButtonDidTap() {
+        isBookmarked.toggle()
+        onBookmarkButtonTapped?()
+    }
+}

--- a/BookTalk/BookTalk/Sources/Presentation/Category/Cell/TableViewCell/CategoryTitleCell.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Category/Cell/TableViewCell/CategoryTitleCell.swift
@@ -33,7 +33,7 @@ final class CategoryTitleCell: UITableViewCell {
 
         firstCategoryTitleLabel.do {
             $0.font = .systemFont(ofSize: 23, weight: .bold)
-            $0.textColor = .accentGreen
+            $0.textColor = .accentOrange
         }
 
         chevronImageView.do {
@@ -44,7 +44,7 @@ final class CategoryTitleCell: UITableViewCell {
 
         secondCategoryTitleLabel.do {
             $0.font = .systemFont(ofSize: 23, weight: .bold)
-            $0.textColor = .accentGreen
+            $0.textColor = .accentOrange
         }
     }
 

--- a/BookTalk/BookTalk/Sources/Presentation/Home/Cell/CollectionViewCell/RecommendationBookCollectionCell.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Home/Cell/CollectionViewCell/RecommendationBookCollectionCell.swift
@@ -21,7 +21,8 @@ final class RecommendationBookCollectionCell: UICollectionViewCell {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
-        setupUI()
+        setViews()
+        setConstraints()
     }
     
     required init?(coder: NSCoder) {
@@ -34,27 +35,19 @@ final class RecommendationBookCollectionCell: UICollectionViewCell {
         imageView.image = UIImage(named: "\(basicBookInfo.coverImageURL)")
         titleLabel.text = basicBookInfo.title
     }
-}
-
-// MARK: - UI Setup
-
-private extension RecommendationBookCollectionCell {
     
-    func setupUI() {
-        contentView.addSubview(imageView)
-        
-        configureImageView()
-        setupConstraints()
-    }
+    // MARK: - Set UI
     
-    func configureImageView() {
+    private func setViews() {
         imageView.do {
             $0.backgroundColor = .gray100
             $0.contentMode = .scaleAspectFit
         }
     }
     
-    func setupConstraints() {
+    private func setConstraints() {
+        contentView.addSubview(imageView)
+        
         imageView.snp.makeConstraints {
             $0.centerX.top.left.equalToSuperview()
             $0.bottom.equalToSuperview().inset(15)

--- a/BookTalk/BookTalk/Sources/Presentation/Home/Cell/TableViewCell/RecommendationBookCell.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Home/Cell/TableViewCell/RecommendationBookCell.swift
@@ -10,10 +10,18 @@ import UIKit
 import SnapKit
 import Then
 
+protocol RecommendationBookCellDelegate: AnyObject {
+    func recommendationBookCell(
+        _ cell: RecommendationBookCell,
+        didSelectBook book: DetailBookInfo
+    )
+}
+
 final class RecommendationBookCell: UITableViewCell {
     
     // MARK: - Properties
     
+    weak var delegate: RecommendationBookCellDelegate?
     private var basicBookInfo: [BasicBookInfo] = []
     private var detailBookInfo: [DetailBookInfo] = []
     private let collectionView: UICollectionView
@@ -39,8 +47,9 @@ final class RecommendationBookCell: UITableViewCell {
     
     // MARK: - Helpers
     
-    func bind(_ basicBookInfo: [BasicBookInfo]) {
-        self.basicBookInfo = basicBookInfo
+    func bind(_ detailBookInfo: [DetailBookInfo]) {
+        self.detailBookInfo = detailBookInfo
+        self.basicBookInfo = detailBookInfo.map { $0.basicBookInfo }
         collectionView.reloadData()
     }
     
@@ -98,8 +107,8 @@ extension RecommendationBookCell: UICollectionViewDataSource {
 extension RecommendationBookCell: UICollectionViewDelegate {
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        let selectedBook = basicBookInfo[indexPath.item]
-        print("DEBUG: Selected \"\(selectedBook)\"")
+        let selectedBook = detailBookInfo[indexPath.item]
+        delegate?.recommendationBookCell(self, didSelectBook: selectedBook)
     }
 }
 

--- a/BookTalk/BookTalk/Sources/Presentation/Home/Cell/TableViewCell/SuggestionCell.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Home/Cell/TableViewCell/SuggestionCell.swift
@@ -30,7 +30,7 @@ final class SuggestionCell: UITableViewCell {
     
     // MARK: - Helpers
     
-    func bind(with text: String) {
+    func bind(_ text: String) {
         suggestionLabel.text = text
     }
 }

--- a/BookTalk/BookTalk/Sources/Presentation/Home/View/HomeViewController.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Home/View/HomeViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class HomeViewController: BaseViewController {
+final class HomeViewController: BaseViewController {
     
     // MARK: - Properties
     
@@ -127,7 +127,7 @@ extension HomeViewController: UITableViewDataSource {
             }
             cell.selectionStyle = .none
             cell.isUserInteractionEnabled = false
-            cell.bind(with: "OOO님, 오늘의 추천 도서를 확인해보세요!")
+            cell.bind("OOO님, 오늘의 추천 도서를 확인해보세요!")
             return cell
         }
         
@@ -137,8 +137,13 @@ extension HomeViewController: UITableViewDataSource {
         ) as? RecommendationBookCell else {
             return UITableViewCell()
         }
+        
+        let sectionIndex = indexPath.section - 1
+        let bookInfo = viewModel.sections[sectionIndex].bookInfo
+        
         cell.selectionStyle = .none
-        cell.bind(viewModel.sections[indexPath.section - 1].basicBookInfo)
+        cell.bind(bookInfo)
+        cell.delegate = self
         return cell
     }
 }
@@ -159,9 +164,7 @@ extension HomeViewController: UITableViewDelegate {
     }
     
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        if section == 0 {
-            return nil
-        }
+        if section == 0 { return nil }
         
         guard let headerView = tableView.dequeueReusableHeaderFooterView(
             withIdentifier: "HomeHeaderView"
@@ -186,18 +189,22 @@ extension HomeViewController: UITableViewDelegate {
     }
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        if indexPath.section == 0 {
-            return UITableView.automaticDimension
-        }
-        
-        return 200
+        return indexPath.section == 0 ? UITableView.automaticDimension : 200
     }
+}
+
+// MARK: - RecommendationBookCellDelegate
+
+extension HomeViewController: RecommendationBookCellDelegate {
     
-    func scrollViewWillBeginDecelerating(_ scrollView: UIScrollView) {
-        if scrollView.panGestureRecognizer.translation(in: scrollView).y < 0 {
-            navigationController?.setNavigationBarHidden(true, animated: true)
-        } else {
-            navigationController?.setNavigationBarHidden(false, animated: true)
-        }
+    func recommendationBookCell(
+        _ cell: RecommendationBookCell,
+        didSelectBook book: DetailBookInfo
+    ) {
+        let detailViewModel = BookDetailViewModel(bookInfo: book)
+        let detailVC = BookDetailViewController()
+        detailVC.viewModel = detailViewModel
+        detailVC.hidesBottomBarWhenPushed = true
+        navigationController?.pushViewController(detailVC, animated: true)
     }
 }

--- a/BookTalk/BookTalk/Sources/Presentation/Search/Cell/SearchCell.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Search/Cell/SearchCell.swift
@@ -10,9 +10,16 @@ import UIKit
 import SnapKit
 import Then
 
+protocol SearchCellDelegate: AnyObject {
+    func searchCell(_ cell: SearchCell, didSelectBook book: DetailBookInfo)
+}
+
 final class SearchCell: UITableViewCell {
     
     // MARK: - Properties
+    
+    weak var delegate: SearchCellDelegate?
+    private var detailBookInfo: DetailBookInfo?
     
     private let coverImageView = UIImageView()
     private let titleLabel = UILabel()
@@ -46,18 +53,14 @@ final class SearchCell: UITableViewCell {
     // MARK: - Helpers
     
     func bind(_ detailBookInfo: DetailBookInfo) {
-        coverImageView.image = UIImage(named: "\(detailBookInfo.basicBookInfo.coverImageURL)")
+        self.detailBookInfo = detailBookInfo
+        coverImageView.image = UIImage(named: detailBookInfo.basicBookInfo.coverImageURL)
         titleLabel.text = detailBookInfo.basicBookInfo.title
         authorLabel.text = detailBookInfo.basicBookInfo.author
         publisherLabel.text = detailBookInfo.publisher
         publicationDateLabel.text = detailBookInfo.publicationDate
-        if detailBookInfo.isAvailable {
-            availabilityLabel.text = "대출 가능"
-            availabilityLabel.textColor = .systemGreen
-        } else {
-            availabilityLabel.text = "대출 불가능"
-            availabilityLabel.textColor = .systemRed
-        }
+        availabilityLabel.text = detailBookInfo.isAvailable ? "대출 가능" : "대출 불가능"
+        availabilityLabel.textColor = detailBookInfo.isAvailable ? .systemGreen : .systemRed
         isFavorite = detailBookInfo.isFavorite
         updateFavoriteButton()
     }

--- a/BookTalk/BookTalk/Sources/Presentation/Search/ViewModel/SearchViewModel.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Search/ViewModel/SearchViewModel.swift
@@ -9,12 +9,7 @@ import Foundation
 
 final class SearchViewModel {
     
-    private(set) var allBooks: [DetailBookInfo] = [] {
-        didSet {
-            
-        }
-    }
-    
+    private(set) var allBooks: [DetailBookInfo] = []
     private(set) var filteredBooks: [DetailBookInfo] = [] {
         didSet {
             onBooksUpdated?()
@@ -36,7 +31,6 @@ final class SearchViewModel {
                 $0.basicBookInfo.author.lowercased().contains(searchText.lowercased())
             }
         }
-        onBooksUpdated?()
     }
     
     private func loadBooks() {

--- a/BookTalk/BookTalk/Sources/Util/Extension/UIColor+.swift
+++ b/BookTalk/BookTalk/Sources/Util/Extension/UIColor+.swift
@@ -23,7 +23,7 @@ extension UIColor {
 
     // MARK: Core
 
-    static let accentGreen: UIColor = .init(hex: 0x2B7746)
+    static let accentOrange: UIColor = .init(hex: 0xE75e01)
     static let bubbleGreen: UIColor = .init(hex: 0xDBF1E3)
 
     // MARK: Grayscale


### PR DESCRIPTION
## 📚 PR 요약
책 상세 페이지 UI 구현 및 피그마 피드백 적용

## 📝 작업 내용
- 내비게이션 바에 하트 버튼 생성
- 플로팅 버튼 구현
- 홈 셀 아이템 및 검색 결과 셀 아이템 선택 시 책 상세 페이지로 이동하도록 연결

## 📌 참고 사항
accentGreen 헥스 값 변경하고 변수명 accentOrange로 전체 변경했습니다!

## 📷 Screenshot
| 상세 페이지 최상단 | 상세 페이지 최하단 | 플로팅 버튼 및 기타 버튼
| -- | -- | -- |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-08-05 at 18 55 22](https://github.com/user-attachments/assets/53334d31-2029-4910-9c07-939a00054edf) | ![Simulator Screenshot - iPhone 15 Pro - 2024-08-05 at 18 55 27](https://github.com/user-attachments/assets/6a6103ad-d20a-445b-9180-fddd965b5462) | ![Simulator Screenshot - iPhone 15 Pro - 2024-08-05 at 18 55 38](https://github.com/user-attachments/assets/40959243-07fb-4a20-9a0a-d5dfb3997308) |

## 📮 관련 이슈
- Resolved: #23 
