### PR TITLE
[refactor] 재사용 가능한 식별자 프로토콜 및 extension

### DIFF
--- a/BookTalk/BookTalk.xcodeproj/project.pbxproj
+++ b/BookTalk/BookTalk.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		051155F12C64B08F00230CFE /* ReusableIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 051155F02C64B08F00230CFE /* ReusableIdentifier.swift */; };
 		054543352C5374D900E64948 /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 054543342C5374D900E64948 /* SearchViewController.swift */; };
 		054543992C5749F300E64948 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 054543982C5749F300E64948 /* HomeViewModel.swift */; };
 		0545439B2C574B9000E64948 /* HomeSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0545439A2C574B9000E64948 /* HomeSection.swift */; };
@@ -66,6 +67,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		051155F02C64B08F00230CFE /* ReusableIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReusableIdentifier.swift; sourceTree = "<group>"; };
 		054543342C5374D900E64948 /* SearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewController.swift; sourceTree = "<group>"; };
 		054543982C5749F300E64948 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		0545439A2C574B9000E64948 /* HomeSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeSection.swift; sourceTree = "<group>"; };
@@ -456,6 +458,7 @@
 				AB2E7BC32C5260AB00CE43CB /* Extension */,
 				AB2E7BD72C53B37500CE43CB /* Constant.swift */,
 				AB3F15452C611DC100C77E13 /* Observable.swift */,
+				051155F02C64B08F00230CFE /* ReusableIdentifier.swift */,
 			);
 			path = Util;
 			sourceTree = "<group>";
@@ -684,6 +687,7 @@
 				AB2E7BDC2C53B64800CE43CB /* CategorySectionKind.swift in Sources */,
 				ABD10DF82C52514F005F290E /* FirstCategoryCell.swift in Sources */,
 				054543F22C5A233600E64948 /* SearchMockData.swift in Sources */,
+				051155F12C64B08F00230CFE /* ReusableIdentifier.swift in Sources */,
 				AB2E7BCE2C53ADF700CE43CB /* BaseViewController.swift in Sources */,
 				0579253F2C4FF4D700834EC6 /* OpenTalkViewController.swift in Sources */,
 				057925432C4FF4E100834EC6 /* MyViewController.swift in Sources */,

--- a/BookTalk/BookTalk/Sources/Presentation/BookDetail/View/BookDetailViewController.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/BookDetail/View/BookDetailViewController.swift
@@ -12,13 +12,13 @@ final class BookDetailViewController: BaseViewController {
     // MARK: - Properties
     
     var viewModel: BookDetailViewModel!
-    
     private var favoriteButton = UIBarButtonItem()
     private let floatingButton = UIButton(type: .system)
     private let likeButton = UIButton(type: .system)
     private let dislikeButton = UIButton(type: .system)
-    
     private let tableView = UITableView(frame: .zero, style: .plain)
+    private let bookInfoID = BookInfoCell.identifier
+    private let nearbyID = NearbyCell.identifier
     
     // MARK: - Lifecycle
     
@@ -150,8 +150,8 @@ final class BookDetailViewController: BaseViewController {
         tableView.do {
             $0.dataSource = self
             $0.separatorInset = .zero
-            $0.register(BookInfoCell.self, forCellReuseIdentifier: "BookInfoCell")
-            $0.register(NearbyCell.self, forCellReuseIdentifier: "NearbyCell")
+            $0.register(BookInfoCell.self, forCellReuseIdentifier: bookInfoID)
+            $0.register(NearbyCell.self, forCellReuseIdentifier: nearbyID)
         }
         
         floatingButton.do {
@@ -234,7 +234,7 @@ extension BookDetailViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         if indexPath.section == 0 {
             guard let cell = tableView.dequeueReusableCell(
-                withIdentifier: "BookInfoCell",
+                withIdentifier: bookInfoID,
                 for: indexPath
             ) as? BookInfoCell else {
                 return UITableViewCell()
@@ -244,7 +244,7 @@ extension BookDetailViewController: UITableViewDataSource {
             return cell
         } else {
             guard let cell = tableView.dequeueReusableCell(
-                withIdentifier: "NearbyCell",
+                withIdentifier: nearbyID,
                 for: indexPath
             ) as? NearbyCell else {
                 return UITableViewCell()

--- a/BookTalk/BookTalk/Sources/Presentation/Home/View/HomeViewController.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Home/View/HomeViewController.swift
@@ -13,6 +13,9 @@ final class HomeViewController: BaseViewController {
     
     private let viewModel = HomeViewModel()
     private let tableView = UITableView(frame: .zero, style: .grouped)
+    private let suggestionID = SuggestionCell.identifier
+    private let headerID = HomeHeaderView.identifier
+    private let recommendationID = RecommendationBookCell.identifier
     
     // MARK: - Lifecycle
     
@@ -81,17 +84,17 @@ final class HomeViewController: BaseViewController {
             
             $0.register(
                 SuggestionCell.self,
-                forCellReuseIdentifier: "SuggestionCell"
+                forCellReuseIdentifier: suggestionID
             )
             
             $0.register(
                 HomeHeaderView.self,
-                forHeaderFooterViewReuseIdentifier: "HomeHeaderView"
+                forHeaderFooterViewReuseIdentifier: headerID
             )
             
             $0.register(
                 RecommendationBookCell.self,
-                forCellReuseIdentifier: "RecommendationBookCell"
+                forCellReuseIdentifier: recommendationID
             )
         }
     }
@@ -120,7 +123,7 @@ extension HomeViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         if indexPath.section == 0 {
             guard let cell = tableView.dequeueReusableCell(
-                withIdentifier: "SuggestionCell",
+                withIdentifier: suggestionID,
                 for: indexPath
             ) as? SuggestionCell else {
                 return UITableViewCell()
@@ -132,7 +135,7 @@ extension HomeViewController: UITableViewDataSource {
         }
         
         guard let cell = tableView.dequeueReusableCell(
-            withIdentifier: "RecommendationBookCell",
+            withIdentifier: recommendationID,
             for: indexPath
         ) as? RecommendationBookCell else {
             return UITableViewCell()
@@ -167,7 +170,7 @@ extension HomeViewController: UITableViewDelegate {
         if section == 0 { return nil }
         
         guard let headerView = tableView.dequeueReusableHeaderFooterView(
-            withIdentifier: "HomeHeaderView"
+            withIdentifier: headerID
         ) as? HomeHeaderView else {
             return nil
         }

--- a/BookTalk/BookTalk/Sources/Presentation/Search/View/SearchViewController.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Search/View/SearchViewController.swift
@@ -13,9 +13,11 @@ final class SearchViewController: BaseViewController {
     
     private let viewModel = SearchViewModel()
     private let searchBar = UISearchBar()
-    private let tableView = UITableView(frame: .zero, style: .plain)
     private var isSearching: Bool = false
     private var searchHistory: [String] = []
+    private let tableView = UITableView(frame: .zero, style: .plain)
+    private let historyID = SearchHistoryCell.identifier
+    private let searchResultID = SearchCell.identifier
     
     // MARK: - Lifecycle
     
@@ -50,8 +52,8 @@ final class SearchViewController: BaseViewController {
         tableView.estimatedRowHeight = 160
         tableView.keyboardDismissMode = .interactive
         tableView.automaticallyAdjustsScrollIndicatorInsets = false
-        tableView.register(SearchHistoryCell.self, forCellReuseIdentifier: "SearchHistoryCell")
-        tableView.register(SearchCell.self, forCellReuseIdentifier: "SearchCell")
+        tableView.register(SearchHistoryCell.self, forCellReuseIdentifier: historyID)
+        tableView.register(SearchCell.self, forCellReuseIdentifier: searchResultID)
     }
     
     override func setConstraints() {
@@ -131,7 +133,10 @@ extension SearchViewController: UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         if isSearching && !viewModel.filteredBooks.isEmpty {
-            guard let cell = tableView.dequeueReusableCell(withIdentifier: "SearchCell", for: indexPath) as? SearchCell else {
+            guard let cell = tableView.dequeueReusableCell(
+                withIdentifier: searchResultID,
+                for: indexPath
+            ) as? SearchCell else {
                 return UITableViewCell()
             }
             let book = viewModel.filteredBooks[indexPath.row]
@@ -140,7 +145,10 @@ extension SearchViewController: UITableViewDataSource {
             cell.bind(book)
             return cell
         } else {
-            guard let cell = tableView.dequeueReusableCell(withIdentifier: "SearchHistoryCell", for: indexPath) as? SearchHistoryCell else {
+            guard let cell = tableView.dequeueReusableCell(
+                withIdentifier: historyID,
+                for: indexPath
+            ) as? SearchHistoryCell else {
                 return UITableViewCell()
             }
             cell.selectionStyle = .none

--- a/BookTalk/BookTalk/Sources/Util/ReusableIdentifier.swift
+++ b/BookTalk/BookTalk/Sources/Util/ReusableIdentifier.swift
@@ -1,0 +1,23 @@
+//
+//  ReusableIdentifier.swift
+//  BookTalk
+//
+//  Created by RAFA on 8/8/24.
+//
+
+import UIKit
+
+protocol ReusableIdentifier: AnyObject { }
+
+extension ReusableIdentifier where Self: UIView {
+    
+    static var identifier: String {
+        return String(describing: self)
+    }
+}
+
+extension UITableViewHeaderFooterView: ReusableIdentifier { }
+
+extension UITableViewCell: ReusableIdentifier { }
+
+extension UICollectionReusableView: ReusableIdentifier { }


### PR DESCRIPTION
## 📚 PR 요약
- 코드에서 재사용 가능한 뷰 클래스에 대해 고유 식별자를 쉽게 접근할 수 있도록 하여, 뷰의 재사용을 간편하게 관리할 수 있음

## 📝 작업 내용
- ReusableIdentifier 프로토콜을 추가하여 재사용 가능한 식별자를 제공
- UIView를 상속하는 클래스에 대해 identifier 속성을 추가하는 확장을 구현
- UITableViewHeaderFooterView, UITableViewCell, UICollectionReusableView에 ReusableIdentifier 프로토콜을 준수하는 확장을 추가

## 📌 참고 사항
### 적용 예시
```swift
// MARK: - Properties

private let suggestionID = SuggestionCell.identifier
private let headerID = HomeHeaderView.identifier
private let recommendationID = RecommendationBookCell.identifier

(생략)

tableView.do {
    (생략)

    $0.register(
        SuggestionCell.self,
        forCellReuseIdentifier: suggestionID
    )
            
    $0.register(
        HomeHeaderView.self,
        forHeaderFooterViewReuseIdentifier: headerID
    )
            
    $0.register(
        RecommendationBookCell.self,
        forCellReuseIdentifier: recommendationID
    )
}
```

## 📷 Screenshot


## 📮 관련 이슈
- Resolved: #32 