### PR TITLE
[feat] 책 상세 페이지 버튼 추가 및 이미지 수정

### DIFF
--- a/BookTalk/BookTalk/Sources/Presentation/BookDetail/Cell/TableViewCell/BookInfoCell.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/BookDetail/Cell/TableViewCell/BookInfoCell.swift
@@ -19,6 +19,7 @@ final class BookInfoCell: BaseTableViewCell {
     private let availabilityLabel = UILabel()
     private let bookInfoStackView = UIStackView()
     private let joinOpenTalkButton = UIButton(type: .system)
+    private let markAsReadButton = UIButton(type: .system)
     
     // MARK: - Bind
     
@@ -109,12 +110,30 @@ final class BookInfoCell: BaseTableViewCell {
             $0.setTitleColor(.white, for: .normal)
             $0.titleLabel?.font = .systemFont(ofSize: 17, weight: .bold)
         }
+        
+        markAsReadButton.do {
+            var config = UIButton.Configuration.plain()
+            config.attributedTitle = AttributedString(
+                NSAttributedString(
+                    string: "읽은 책으로 추가하기",
+                    attributes: [.font: UIFont.systemFont(ofSize: 15, weight: .bold)]
+                )
+            )
+            config.image = UIImage(systemName: "plus")?
+                .withConfiguration(UIImage.SymbolConfiguration(pointSize: 12, weight: .bold))
+            config.imagePlacement = .trailing
+            config.imagePadding = 5
+            
+            $0.configuration = config
+        }
     }
     
     override func setConstraints() {
-        [bookImageView, titleLabel, bookInfoStackView, joinOpenTalkButton].forEach {
-            contentView.addSubview($0)
-        }
+        [bookImageView,
+         titleLabel,
+         bookInfoStackView,
+         joinOpenTalkButton,
+         markAsReadButton].forEach { contentView.addSubview($0) }
         
         bookImageView.snp.makeConstraints {
             $0.centerX.equalToSuperview()
@@ -138,8 +157,14 @@ final class BookInfoCell: BaseTableViewCell {
             $0.centerX.equalToSuperview()
             $0.top.equalTo(bookInfoStackView.snp.bottom).offset(15)
             $0.left.equalTo(bookInfoStackView)
-            $0.bottom.equalToSuperview().offset(-15)
             $0.height.equalTo(50)
+        }
+        
+        markAsReadButton.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.top.equalTo(joinOpenTalkButton.snp.bottom).offset(15)
+            $0.left.equalTo(joinOpenTalkButton)
+            $0.bottom.equalToSuperview().offset(-15)
         }
     }
 }

--- a/BookTalk/BookTalk/Sources/Presentation/BookDetail/View/BookDetailViewController.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/BookDetail/View/BookDetailViewController.swift
@@ -96,7 +96,7 @@ final class BookDetailViewController: BaseViewController {
             var config = UIButton.Configuration.filled()
             config.baseBackgroundColor = .accentOrange
             config.cornerStyle = .capsule
-            config.image = UIImage(systemName: "plus")?
+            config.image = UIImage(systemName: "ellipsis")?
                 .withConfiguration(UIImage.SymbolConfiguration(pointSize: 20, weight: .medium))
             $0.configuration = config
             $0.layer.shadowRadius = 10


### PR DESCRIPTION
## 📚 PR 요약
책 상세 페이지 버튼 추가 및 이미지 수정

## 📝 작업 내용
- '읽은 책으로 추가하기' 버튼 추가 구현
- 플로팅 버튼 이미지 변경

## 📌 참고 사항


## 📷 Screenshot
| 읽은 책으로 추가하기 버튼 / 플로팅 버튼 비활성 | 읽은 책으로 추가하기 버튼 / 플로팅 버튼 활성
| -- | -- |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-08-10 at 01 43 11](https://github.com/user-attachments/assets/eb653411-1b14-4b44-9d8d-9da4ea9661cd) | ![Simulator Screenshot - iPhone 15 Pro - 2024-08-10 at 01 43 16](https://github.com/user-attachments/assets/09408303-31d9-4b42-95e7-d561873fdce1) |

## 📮 관련 이슈
- Resolved: #39 
