### PR TITLE
[feat] 카테고리 전체보기 필터에 따라 api 연결

### DIFF
--- a/BookTalk/BookTalk.xcodeproj/project.pbxproj
+++ b/BookTalk/BookTalk.xcodeproj/project.pbxproj
@@ -106,6 +106,7 @@
 		AB82055C2C6E66BD0014C5A5 /* GenreTrendRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB82055B2C6E66BD0014C5A5 /* GenreTrendRequestDTO.swift */; };
 		AB8205602C6E67850014C5A5 /* LoanItemResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB82055F2C6E67850014C5A5 /* LoanItemResponseDTO.swift */; };
 		AB8205622C6E687D0014C5A5 /* Encodable+.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB8205612C6E687D0014C5A5 /* Encodable+.swift */; };
+		ABB901A42C71EDD700727875 /* GenreRandomRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABB901A32C71EDD700727875 /* GenreRandomRequestDTO.swift */; };
 		ABD10DF82C52514F005F290E /* FirstCategoryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABD10DF72C52514F005F290E /* FirstCategoryCell.swift */; };
 		ABDADA3E2C70A6A3009ED3BB /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABDADA3D2C70A6A3009ED3BB /* Date+.swift */; };
 		ABED440D2C66549E0073398A /* DGCharts in Frameworks */ = {isa = PBXBuildFile; productRef = ABED440C2C66549E0073398A /* DGCharts */; };
@@ -215,6 +216,7 @@
 		AB82055B2C6E66BD0014C5A5 /* GenreTrendRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = GenreTrendRequestDTO.swift; path = BookTalk/Sources/DTO/Genre/Request/GenreTrendRequestDTO.swift; sourceTree = SOURCE_ROOT; };
 		AB82055F2C6E67850014C5A5 /* LoanItemResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoanItemResponseDTO.swift; sourceTree = "<group>"; };
 		AB8205612C6E687D0014C5A5 /* Encodable+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Encodable+.swift"; sourceTree = "<group>"; };
+		ABB901A32C71EDD700727875 /* GenreRandomRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenreRandomRequestDTO.swift; sourceTree = "<group>"; };
 		ABD10DF72C52514F005F290E /* FirstCategoryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstCategoryCell.swift; sourceTree = "<group>"; };
 		ABDADA3D2C70A6A3009ED3BB /* Date+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+.swift"; sourceTree = "<group>"; };
 		ABED440F2C665CDB0073398A /* GoalViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalViewModel.swift; sourceTree = "<group>"; };
@@ -803,6 +805,7 @@
 			isa = PBXGroup;
 			children = (
 				AB82055B2C6E66BD0014C5A5 /* GenreTrendRequestDTO.swift */,
+				ABB901A32C71EDD700727875 /* GenreRandomRequestDTO.swift */,
 			);
 			path = Request;
 			sourceTree = "<group>";
@@ -1040,6 +1043,7 @@
 				0579D1102C6C9E410032AC1C /* HomeSectionType.swift in Sources */,
 				054543A92C57531C00E64948 /* HomeHeaderView.swift in Sources */,
 				AB4CBA5D2C6BAFA5009A2AB6 /* NetworkEnvironment.swift in Sources */,
+				ABB901A42C71EDD700727875 /* GenreRandomRequestDTO.swift in Sources */,
 				AB4CBA6E2C6DE391009A2AB6 /* NetworkError.swift in Sources */,
 				AB0C0F5F2C5BE285007812C5 /* OpenTalkPageType.swift in Sources */,
 				AB22AD3E2C4E8D9D00C9A0F3 /* SceneDelegate.swift in Sources */,

--- a/BookTalk/BookTalk.xcodeproj/project.pbxproj
+++ b/BookTalk/BookTalk.xcodeproj/project.pbxproj
@@ -107,6 +107,7 @@
 		AB8205602C6E67850014C5A5 /* LoanItemResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB82055F2C6E67850014C5A5 /* LoanItemResponseDTO.swift */; };
 		AB8205622C6E687D0014C5A5 /* Encodable+.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB8205612C6E687D0014C5A5 /* Encodable+.swift */; };
 		ABB901A42C71EDD700727875 /* GenreRandomRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABB901A32C71EDD700727875 /* GenreRandomRequestDTO.swift */; };
+		ABB901A82C7241AD00727875 /* IndicatorFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABB901A72C7241AD00727875 /* IndicatorFooterView.swift */; };
 		ABD10DF82C52514F005F290E /* FirstCategoryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABD10DF72C52514F005F290E /* FirstCategoryCell.swift */; };
 		ABDADA3E2C70A6A3009ED3BB /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABDADA3D2C70A6A3009ED3BB /* Date+.swift */; };
 		ABED440D2C66549E0073398A /* DGCharts in Frameworks */ = {isa = PBXBuildFile; productRef = ABED440C2C66549E0073398A /* DGCharts */; };
@@ -217,6 +218,7 @@
 		AB82055F2C6E67850014C5A5 /* LoanItemResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoanItemResponseDTO.swift; sourceTree = "<group>"; };
 		AB8205612C6E687D0014C5A5 /* Encodable+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Encodable+.swift"; sourceTree = "<group>"; };
 		ABB901A32C71EDD700727875 /* GenreRandomRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenreRandomRequestDTO.swift; sourceTree = "<group>"; };
+		ABB901A72C7241AD00727875 /* IndicatorFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndicatorFooterView.swift; sourceTree = "<group>"; };
 		ABD10DF72C52514F005F290E /* FirstCategoryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstCategoryCell.swift; sourceTree = "<group>"; };
 		ABDADA3D2C70A6A3009ED3BB /* Date+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+.swift"; sourceTree = "<group>"; };
 		ABED440F2C665CDB0073398A /* GoalViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalViewModel.swift; sourceTree = "<group>"; };
@@ -672,6 +674,7 @@
 			isa = PBXGroup;
 			children = (
 				ABD10DF72C52514F005F290E /* FirstCategoryCell.swift */,
+				ABB901A72C7241AD00727875 /* IndicatorFooterView.swift */,
 			);
 			path = CollectionViewCell;
 			sourceTree = "<group>";
@@ -1057,6 +1060,7 @@
 				AB0C0F652C5BF3E3007812C5 /* OtherChatBubbleCell.swift in Sources */,
 				054543F72C5A249200E64948 /* SearchViewModel.swift in Sources */,
 				AB2E7BDA2C53B3F300CE43CB /* SubcategoryViewController.swift in Sources */,
+				ABB901A82C7241AD00727875 /* IndicatorFooterView.swift in Sources */,
 				AB4CBA562C6B44D7009A2AB6 /* LikedTitleHeaderView.swift in Sources */,
 				AB8205602C6E67850014C5A5 /* LoanItemResponseDTO.swift in Sources */,
 				051156052C64C73F00230CFE /* BaseCollectionViewCell.swift in Sources */,

--- a/BookTalk/BookTalk.xcodeproj/project.pbxproj
+++ b/BookTalk/BookTalk.xcodeproj/project.pbxproj
@@ -74,9 +74,9 @@
 		AB2E7BE72C53D2A300CE43CB /* ShowAllBookCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2E7BE62C53D2A300CE43CB /* ShowAllBookCell.swift */; };
 		AB2E7BEA2C53D69600CE43CB /* BookImageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2E7BE92C53D69600CE43CB /* BookImageCell.swift */; };
 		AB2E7BED2C53DB2200CE43CB /* BooksWithHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2E7BEC2C53DB2200CE43CB /* BooksWithHeader.swift */; };
-		AB2E7BF22C53EDD800CE43CB /* AllBookImagesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2E7BF12C53EDD800CE43CB /* AllBookImagesViewController.swift */; };
+		AB2E7BF22C53EDD800CE43CB /* AllBooksViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2E7BF12C53EDD800CE43CB /* AllBooksViewController.swift */; };
 		AB2E7BF62C53F68200CE43CB /* BookSortType.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2E7BF52C53F68200CE43CB /* BookSortType.swift */; };
-		AB2E7BF82C53F71B00CE43CB /* ThirdCategoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2E7BF72C53F71B00CE43CB /* ThirdCategoryViewModel.swift */; };
+		AB2E7BF82C53F71B00CE43CB /* AllBooksViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2E7BF72C53F71B00CE43CB /* AllBooksViewModel.swift */; };
 		AB2E7BFA2C54A53900CE43CB /* CategorySelectModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2E7BF92C54A53900CE43CB /* CategorySelectModalViewController.swift */; };
 		AB2E7BFE2C5602A500CE43CB /* Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2E7BFD2C5602A500CE43CB /* Category.swift */; };
 		AB2E7C042C565B3A00CE43CB /* FirstCategoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2E7C032C565B3A00CE43CB /* FirstCategoryViewController.swift */; };
@@ -185,9 +185,9 @@
 		AB2E7BE62C53D2A300CE43CB /* ShowAllBookCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowAllBookCell.swift; sourceTree = "<group>"; };
 		AB2E7BE92C53D69600CE43CB /* BookImageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookImageCell.swift; sourceTree = "<group>"; };
 		AB2E7BEC2C53DB2200CE43CB /* BooksWithHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BooksWithHeader.swift; sourceTree = "<group>"; };
-		AB2E7BF12C53EDD800CE43CB /* AllBookImagesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllBookImagesViewController.swift; sourceTree = "<group>"; };
+		AB2E7BF12C53EDD800CE43CB /* AllBooksViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllBooksViewController.swift; sourceTree = "<group>"; };
 		AB2E7BF52C53F68200CE43CB /* BookSortType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookSortType.swift; sourceTree = "<group>"; };
-		AB2E7BF72C53F71B00CE43CB /* ThirdCategoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThirdCategoryViewModel.swift; sourceTree = "<group>"; };
+		AB2E7BF72C53F71B00CE43CB /* AllBooksViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllBooksViewModel.swift; sourceTree = "<group>"; };
 		AB2E7BF92C54A53900CE43CB /* CategorySelectModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategorySelectModalViewController.swift; sourceTree = "<group>"; };
 		AB2E7BFD2C5602A500CE43CB /* Category.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Category.swift; sourceTree = "<group>"; };
 		AB2E7C032C565B3A00CE43CB /* FirstCategoryViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FirstCategoryViewController.swift; sourceTree = "<group>"; };
@@ -617,7 +617,7 @@
 			isa = PBXGroup;
 			children = (
 				AB2E7BDE2C53B70700CE43CB /* SubcategoryViewModel.swift */,
-				AB2E7BF72C53F71B00CE43CB /* ThirdCategoryViewModel.swift */,
+				AB2E7BF72C53F71B00CE43CB /* AllBooksViewModel.swift */,
 				AB23BF092C638EA300E12702 /* CategorySelectModalViewModel.swift */,
 			);
 			path = ViewModel;
@@ -840,7 +840,7 @@
 			children = (
 				AB2E7C032C565B3A00CE43CB /* FirstCategoryViewController.swift */,
 				AB2E7BD92C53B3F300CE43CB /* SubcategoryViewController.swift */,
-				AB2E7BF12C53EDD800CE43CB /* AllBookImagesViewController.swift */,
+				AB2E7BF12C53EDD800CE43CB /* AllBooksViewController.swift */,
 				AB2E7BF92C54A53900CE43CB /* CategorySelectModalViewController.swift */,
 			);
 			path = View;
@@ -1020,7 +1020,7 @@
 				AB4CBA662C6BB398009A2AB6 /* KeychainManager.swift in Sources */,
 				051156012C64C6F100230CFE /* BaseTableViewHeaderFooterView.swift in Sources */,
 				AB0C0F7A2C5F6D19007812C5 /* NowReadingCell.swift in Sources */,
-				AB2E7BF22C53EDD800CE43CB /* AllBookImagesViewController.swift in Sources */,
+				AB2E7BF22C53EDD800CE43CB /* AllBooksViewController.swift in Sources */,
 				ABED44192C666F6E0073398A /* GoalChartCell.swift in Sources */,
 				AB2E7BE32C53C17100CE43CB /* CategoryTitleCell.swift in Sources */,
 				AB4CBA6A2C6DD6E3009A2AB6 /* ServerRequestInterceptor.swift in Sources */,
@@ -1081,7 +1081,7 @@
 				AB4CBA4D2C6B2E4B009A2AB6 /* ChatMenuViewModel.swift in Sources */,
 				057925432C4FF4E100834EC6 /* MyViewController.swift in Sources */,
 				AB4CBA702C6DEFB8009A2AB6 /* Keychain+.swift in Sources */,
-				AB2E7BF82C53F71B00CE43CB /* ThirdCategoryViewModel.swift in Sources */,
+				AB2E7BF82C53F71B00CE43CB /* AllBooksViewModel.swift in Sources */,
 				AB2E7BD82C53B37500CE43CB /* Constant.swift in Sources */,
 				AB0C0F782C5F639C007812C5 /* ChatMenuViewController.swift in Sources */,
 				0579D1092C6C9D5C0032AC1C /* PaddedLabel.swift in Sources */,

--- a/BookTalk/BookTalk/Sources/DTO/Genre/Request/GenreRandomRequestDTO.swift
+++ b/BookTalk/BookTalk/Sources/DTO/Genre/Request/GenreRandomRequestDTO.swift
@@ -1,0 +1,13 @@
+//
+//  GenreRandomRequestDTO.swift
+//  BookTalk
+//
+//  Created by 김민 on 8/18/24.
+//
+
+import Foundation
+
+struct GenreRandomRequestDTO: Encodable {
+    let genreCode: String
+    let maxSize: String
+}

--- a/BookTalk/BookTalk/Sources/DTO/Genre/Request/GenreTrendRequestDTO.swift
+++ b/BookTalk/BookTalk/Sources/DTO/Genre/Request/GenreTrendRequestDTO.swift
@@ -9,6 +9,6 @@ import Foundation
 
 struct GenreTrendRequestDTO: Encodable {
     let genreCode: String
-    let pageNo: String = "1"
-    let pageSize: String = "10"
+    var pageNo: String = "1"
+    var pageSize: String = "10"
 }

--- a/BookTalk/BookTalk/Sources/Network/Genre/GenreService.swift
+++ b/BookTalk/BookTalk/Sources/Network/Genre/GenreService.swift
@@ -24,4 +24,33 @@ struct GenreService {
 
         return result.map { $0.toBookModel() }
     }
+
+    static func getBooksByFilter(of filter: BookSortType, with requestDTO: GenreTrendRequestDTO) async throws -> [Book] {
+        var result: [LoanItemResponseDTO] = .init()
+
+        switch filter {
+        case .popularityPerWeek:
+            result = try await NetworkService.shared.request(
+                target: GenreTarget.getWeekTrend(params: requestDTO)
+            )
+
+        case .popularityPerMonth:
+            result = try await NetworkService.shared.request(
+                target: GenreTarget.getMonthTrend(params: requestDTO)
+            )
+
+        case .newest, .random:
+            break
+        }
+
+        return result.map { $0.toBookModel() }
+    }
+
+    static func getRandomBooks(with requestDTO: GenreRandomRequestDTO) async throws -> [Book] {
+        let result: [LoanItemResponseDTO] = try await NetworkService.shared.request(
+            target: GenreTarget.getRandom(params: requestDTO)
+        )
+
+        return result.map { $0.toBookModel() }
+    }
 }

--- a/BookTalk/BookTalk/Sources/Network/Genre/GenreTarget.swift
+++ b/BookTalk/BookTalk/Sources/Network/Genre/GenreTarget.swift
@@ -12,6 +12,9 @@ import Alamofire
 enum GenreTarget {
     case getThisWeekTrend(params: GenreTrendRequestDTO)
     case getNewTrend(params: GenreTrendRequestDTO)
+    case getRandom(params: GenreRandomRequestDTO)
+    case getWeekTrend(params: GenreTrendRequestDTO)
+    case getMonthTrend(params: GenreTrendRequestDTO)
 }
 
 extension GenreTarget: TargetType {
@@ -22,12 +25,18 @@ extension GenreTarget: TargetType {
             return "/api/genre/thisWeekTrend"
         case .getNewTrend:
             return "/api/genre/newTrend"
+        case .getRandom:
+            return "/api/genre/random"
+        case .getWeekTrend:
+            return "/api/genre/aWeekTrend"
+        case .getMonthTrend:
+            return "/api/genre/aMonthTrend"
         }
     }
     
     var method: HTTPMethod {
         switch self {
-        case .getThisWeekTrend, .getNewTrend:
+        default:
             return .get
         }
     }
@@ -35,7 +44,12 @@ extension GenreTarget: TargetType {
     var task: APITask {
         switch self {
         case let .getThisWeekTrend(params),
-            let .getNewTrend(params):
+            let .getNewTrend(params),
+            let .getWeekTrend(params),
+            let .getMonthTrend(params):
+            return .requestParameters(parameters: params.toDictionary())
+
+        case let .getRandom(params):
             return .requestParameters(parameters: params.toDictionary())
         }
     }

--- a/BookTalk/BookTalk/Sources/Presentation/Category/Cell/CollectionViewCell/IndicatorFooterView.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Category/Cell/CollectionViewCell/IndicatorFooterView.swift
@@ -27,13 +27,6 @@ final class IndicatorFooterView: BaseCollectionViewHeaderFooterView {
     
     // MARK: - UI Setup
 
-    override func setViews() {
-        indicatorView.do {
-            $0.color = .accentOrange
-            $0.hidesWhenStopped = true
-        }
-    }
-
     override func setConstraints() {
         addSubview(indicatorView)
 

--- a/BookTalk/BookTalk/Sources/Presentation/Category/Cell/CollectionViewCell/IndicatorFooterView.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Category/Cell/CollectionViewCell/IndicatorFooterView.swift
@@ -1,0 +1,44 @@
+//
+//  IndicatorFooterView.swift
+//  BookTalk
+//
+//  Created by 김민 on 8/18/24.
+//
+
+import UIKit
+
+final class IndicatorFooterView: BaseCollectionViewHeaderFooterView {
+
+    // MARK: - Properties
+
+    private let indicatorView = UIActivityIndicatorView(style: .medium)
+
+    // MARK: - Initializer
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        indicatorView.startAnimating() 
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - UI Setup
+
+    override func setViews() {
+        indicatorView.do {
+            $0.color = .accentOrange
+            $0.hidesWhenStopped = true
+        }
+    }
+
+    override func setConstraints() {
+        addSubview(indicatorView)
+
+        indicatorView.snp.makeConstraints {
+            $0.center.equalToSuperview()
+        }
+    }
+}

--- a/BookTalk/BookTalk/Sources/Presentation/Category/View/AllBooksViewController.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Category/View/AllBooksViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class AllBookImagesViewController: BaseViewController {
+final class AllBooksViewController: BaseViewController {
 
     // MARK: - Properties
 
@@ -15,7 +15,7 @@ final class AllBookImagesViewController: BaseViewController {
     private let sortButton = UIButton()
     private let booksCollectionView = UICollectionView(frame: .zero, collectionViewLayout: .init())
 
-    private let viewModel = ThirdCategoryViewModel()
+    private let viewModel = AllBooksViewModel()
 
     // MARK: - Lifecycle
 
@@ -119,7 +119,7 @@ final class AllBookImagesViewController: BaseViewController {
 
 // MARK: - UICollectionViewDataSource
 
-extension AllBookImagesViewController: UICollectionViewDataSource {
+extension AllBooksViewController: UICollectionViewDataSource {
 
     func collectionView(
         _ collectionView: UICollectionView,
@@ -143,7 +143,7 @@ extension AllBookImagesViewController: UICollectionViewDataSource {
 
 // MARK: - UICollectionViewDelegateFlowLayout
 
-extension AllBookImagesViewController: UICollectionViewDelegateFlowLayout {
+extension AllBooksViewController: UICollectionViewDelegateFlowLayout {
 
     func collectionView(
         _ collectionView: UICollectionView,

--- a/BookTalk/BookTalk/Sources/Presentation/Category/View/AllBooksViewController.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Category/View/AllBooksViewController.swift
@@ -14,9 +14,20 @@ final class AllBooksViewController: BaseViewController {
     private let sortView = UIView()
     private let sortButton = UIButton()
     private let booksCollectionView = UICollectionView(frame: .zero, collectionViewLayout: .init())
+    private let viewModel: AllBooksViewModel
 
-    private let viewModel = AllBooksViewModel()
+    // MARK: - Initializer
 
+    init(viewModel: AllBooksViewModel) {
+        self.viewModel = viewModel
+
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     // MARK: - Lifecycle
 
     override func viewDidLoad() {

--- a/BookTalk/BookTalk/Sources/Presentation/Category/View/SubcategoryViewController.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Category/View/SubcategoryViewController.swift
@@ -192,9 +192,11 @@ extension SubcategoryViewController: UITableViewDelegate {
             present(modalViewController, animated: true)
 
         case .allBookButton:
-            let thirdCategoryViewController = AllBooksViewController()
-            thirdCategoryViewController.hidesBottomBarWhenPushed = true
-            navigationController?.pushViewController(thirdCategoryViewController, animated: true)
+            let viewModel = AllBooksViewModel(genreCode: "")
+            let allBooksViewController = AllBooksViewController(viewModel: viewModel)
+
+            allBooksViewController.hidesBottomBarWhenPushed = true
+            navigationController?.pushViewController(allBooksViewController, animated: true)
 
         case .banner, .newBooks, .popularBooks:
             return

--- a/BookTalk/BookTalk/Sources/Presentation/Category/View/SubcategoryViewController.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Category/View/SubcategoryViewController.swift
@@ -192,7 +192,7 @@ extension SubcategoryViewController: UITableViewDelegate {
             present(modalViewController, animated: true)
 
         case .allBookButton:
-            let thirdCategoryViewController = AllBookImagesViewController()
+            let thirdCategoryViewController = AllBooksViewController()
             thirdCategoryViewController.hidesBottomBarWhenPushed = true
             navigationController?.pushViewController(thirdCategoryViewController, animated: true)
 

--- a/BookTalk/BookTalk/Sources/Presentation/Category/View/SubcategoryViewController.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Category/View/SubcategoryViewController.swift
@@ -192,7 +192,9 @@ extension SubcategoryViewController: UITableViewDelegate {
             present(modalViewController, animated: true)
 
         case .allBookButton:
-            let viewModel = AllBooksViewModel(genreCode: "")
+            let viewModel = AllBooksViewModel(
+                genreCode: "\(viewModel.firstCategoryType.rawValue)\(viewModel.subcategoryIdx)"
+            )
             let allBooksViewController = AllBooksViewController(viewModel: viewModel)
 
             allBooksViewController.hidesBottomBarWhenPushed = true

--- a/BookTalk/BookTalk/Sources/Presentation/Category/ViewModel/AllBooksViewModel.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Category/ViewModel/AllBooksViewModel.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-final class ThirdCategoryViewModel {
+final class AllBooksViewModel {
 
     enum Action {
         case sort(_ sortType: BookSortType)

--- a/BookTalk/BookTalk/Sources/Presentation/Category/ViewModel/AllBooksViewModel.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Category/ViewModel/AllBooksViewModel.swift
@@ -11,6 +11,8 @@ final class AllBooksViewModel {
 
     // MARK: - Properties
 
+    var books = Observable<[Book]>([])
+
     private let genreCode: String
 
     // MARK: - Initializer
@@ -26,6 +28,63 @@ final class AllBooksViewModel {
     }
 
     func send(action: Action) {
-        
+        switch action {
+        case let .sort(sortType):
+            loadBooks(of: sortType)
+        }
+    }
+
+    private func loadBooks(of type: BookSortType) {
+        switch type {
+        case .popularityPerWeek, .popularityPerMonth:
+            Task {
+                do {
+                    let popularBooks = try await GenreService.getBooksByFilter(
+                        of: type,
+                        with: .init(genreCode: genreCode ,pageNo: "1",pageSize: "10")
+                    )
+
+                    await MainActor.run {
+                        books.value = popularBooks
+                    }
+                } catch let error as NetworkError {
+                    print("Error: \(error.localizedDescription)")
+                }
+            }
+
+        case .newest:
+            Task {
+                do {
+                    let popularBooks = try await GenreService.getNewTrend(
+                        with: .init(
+                            genreCode: genreCode,
+                            pageNo: "1",
+                            pageSize: "10"
+                        )
+                    )
+
+                    await MainActor.run {
+                        books.value = popularBooks
+                    }
+                } catch let error as NetworkError {
+                    print("Error: \(error.localizedDescription)")
+                }
+            }
+
+        case .random:
+            Task {
+                do {
+                    let popularBooks = try await GenreService.getRandomBooks(
+                        with: .init(genreCode: genreCode, maxSize: "10")
+                    )
+
+                    await MainActor.run {
+                        books.value = popularBooks
+                    }
+                } catch let error as NetworkError {
+                    print("Error: \(error.localizedDescription)")
+                }
+            }
+        }
     }
 }

--- a/BookTalk/BookTalk/Sources/Presentation/Category/ViewModel/AllBooksViewModel.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Category/ViewModel/AllBooksViewModel.swift
@@ -9,6 +9,18 @@ import Foundation
 
 final class AllBooksViewModel {
 
+    // MARK: - Properties
+
+    private let genreCode: String
+
+    // MARK: - Initializer
+
+    init(genreCode: String) {
+        self.genreCode = genreCode
+    }
+
+    // MARK: - Helpers
+
     enum Action {
         case sort(_ sortType: BookSortType)
     }

--- a/BookTalk/BookTalk/Sources/Presentation/Category/ViewModel/SubcategoryViewModel.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Category/ViewModel/SubcategoryViewModel.swift
@@ -22,17 +22,16 @@ final class SubcategoryViewModel {
     var subcategory: Observable<String> = Observable("전체")
     var popularBooks = Observable<BooksWithHeader>(.init(headerTitle: "", books: []))
     var newBooks = Observable<BooksWithHeader>(.init(headerTitle: "", books: []))
-
-    private var subcategoryIdx: Int = 0 {
+    var subcategoryIdx: Int = 0 {
         didSet {
             send(action: .loadPopularBooks(subcategoryIdx: subcategoryIdx))
             send(action: .loadNewBooks(subcategoryIdx: subcategoryIdx))
         }
     }
 
-    // MARK: - Initializer
-
     let firstCategoryType: CategoryType
+
+    // MARK: - Initializer
 
     init(
         firstCategoryType: CategoryType
@@ -52,9 +51,7 @@ final class SubcategoryViewModel {
             let (month, week) = Date().currentWeekOfMonth()
             popularBooks.value.headerTitle = "\(month)월 \(week)주차 TOP 10"
 
-            let genreCode = getGenreCode(
-                firstCategoryType.rawValue, subcategoryIdx
-            )
+            let genreCode = "\(firstCategoryType.rawValue)\(subcategoryIdx)"
 
             Task {
                 do {
@@ -72,9 +69,7 @@ final class SubcategoryViewModel {
             }
 
         case let .loadNewBooks(subcategoryIdx):
-            let genreCode = getGenreCode(
-                firstCategoryType.rawValue, subcategoryIdx
-            )
+            let genreCode = "\(firstCategoryType.rawValue)\(subcategoryIdx)"
 
             Task {
                 do {
@@ -92,9 +87,5 @@ final class SubcategoryViewModel {
                 }
             }
         }
-    }
-
-    private func getGenreCode(_ firstCategoryCode: Int, _ subcategoryIndex: Int) -> String {
-        return "\(firstCategoryCode)\(subcategoryIndex)"
     }
 }

--- a/BookTalk/BookTalk/Sources/Presentation/Component/BookImageCell.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Component/BookImageCell.swift
@@ -48,9 +48,9 @@ final class BookImageCell: BaseCollectionViewCell {
     }
 
     func bind(with book: Book) {
-        guard let url = URL(string: book.imageURL) else { return }
-
-        bookImageView.kf.setImage(with: url)
         bookNameLabel.text = book.title
+        
+        guard let url = URL(string: book.imageURL) else { return }
+        bookImageView.kf.setImage(with: url)
     }
 }


### PR DESCRIPTION
## 📚 PR 요약
카테고리 전체보기 필터에 따라 api 연결

## 📝 작업 내용
- 무작위순, 일주일 인기순, 한달 인기순 api 연결
- 필터에 따라 api 호출
- 무한스크롤 (더 로딩이 되는 경우 footer로 indicator 보여주기)

## 📷 Screenshot
<img src = "https://github.com/user-attachments/assets/3f9b3900-309a-4d2b-bbd9-dad3ca66b939" width = 30%>

## 📮 관련 이슈
- Resolved: #69 
