### PR TITLE
[feat] 카카오 로그인 / 애플 로그인 기본 세팅

### DIFF
--- a/BookTalk/BookTalk.xcodeproj/project.pbxproj
+++ b/BookTalk/BookTalk.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		0579D1182C6C9FC30032AC1C /* KeywordViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0579D1172C6C9FC30032AC1C /* KeywordViewModel.swift */; };
 		AB0784812C74F8910017812F /* KakaoSDKAuth in Frameworks */ = {isa = PBXBuildFile; productRef = AB0784802C74F8910017812F /* KakaoSDKAuth */; };
 		AB0784832C74F8910017812F /* KakaoSDKUser in Frameworks */ = {isa = PBXBuildFile; productRef = AB0784822C74F8910017812F /* KakaoSDKUser */; };
+		AB0784852C74FA1D0017812F /* OAuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0784842C74FA1D0017812F /* OAuthManager.swift */; };
 		AB0C0F592C5BD98B007812C5 /* OpenTalkPageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0C0F582C5BD98B007812C5 /* OpenTalkPageCell.swift */; };
 		AB0C0F5F2C5BE285007812C5 /* OpenTalkPageType.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0C0F5E2C5BE285007812C5 /* OpenTalkPageType.swift */; };
 		AB0C0F612C5BE9B1007812C5 /* ChatViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0C0F602C5BE9B1007812C5 /* ChatViewController.swift */; };
@@ -185,6 +186,7 @@
 		0579D1132C6C9F8C0032AC1C /* KeywordCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeywordCell.swift; sourceTree = "<group>"; };
 		0579D1152C6C9FA30032AC1C /* KeywordCollectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeywordCollectionCell.swift; sourceTree = "<group>"; };
 		0579D1172C6C9FC30032AC1C /* KeywordViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeywordViewModel.swift; sourceTree = "<group>"; };
+		AB0784842C74FA1D0017812F /* OAuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthManager.swift; sourceTree = "<group>"; };
 		AB0C0F582C5BD98B007812C5 /* OpenTalkPageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenTalkPageCell.swift; sourceTree = "<group>"; };
 		AB0C0F5E2C5BE285007812C5 /* OpenTalkPageType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenTalkPageType.swift; sourceTree = "<group>"; };
 		AB0C0F602C5BE9B1007812C5 /* ChatViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewController.swift; sourceTree = "<group>"; };
@@ -456,6 +458,7 @@
 			isa = PBXGroup;
 			children = (
 				054FA1742C74643C0007D9C9 /* OnboardingManager.swift */,
+				AB0784842C74FA1D0017812F /* OAuthManager.swift */,
 			);
 			path = Manager;
 			sourceTree = "<group>";
@@ -1205,6 +1208,7 @@
 				AB2E7BE72C53D2A300CE43CB /* ShowAllBookCell.swift in Sources */,
 				056F304E2C60D54500931302 /* BookDetailViewModel.swift in Sources */,
 				AB4CBA622C6BB191009A2AB6 /* APITask.swift in Sources */,
+				AB0784852C74FA1D0017812F /* OAuthManager.swift in Sources */,
 				AB82055C2C6E66BD0014C5A5 /* GenreTrendRequestDTO.swift in Sources */,
 				AB4CBA522C6B31BC009A2AB6 /* AddBookViewController.swift in Sources */,
 				AB4CBA602C6BB0E9009A2AB6 /* TargetType.swift in Sources */,

--- a/BookTalk/BookTalk.xcodeproj/project.pbxproj
+++ b/BookTalk/BookTalk.xcodeproj/project.pbxproj
@@ -1438,7 +1438,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = min.BookTalk;
+				PRODUCT_BUNDLE_IDENTIFIER = ieum.Readables;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -1475,7 +1475,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = min.BookTalk;
+				PRODUCT_BUNDLE_IDENTIFIER = ieum.Readables;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;

--- a/BookTalk/BookTalk.xcodeproj/project.pbxproj
+++ b/BookTalk/BookTalk.xcodeproj/project.pbxproj
@@ -187,6 +187,7 @@
 		0579D1152C6C9FA30032AC1C /* KeywordCollectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeywordCollectionCell.swift; sourceTree = "<group>"; };
 		0579D1172C6C9FC30032AC1C /* KeywordViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeywordViewModel.swift; sourceTree = "<group>"; };
 		AB0784842C74FA1D0017812F /* OAuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthManager.swift; sourceTree = "<group>"; };
+		AB0784862C74FF2C0017812F /* BookTalk.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = BookTalk.entitlements; sourceTree = "<group>"; };
 		AB0C0F582C5BD98B007812C5 /* OpenTalkPageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenTalkPageCell.swift; sourceTree = "<group>"; };
 		AB0C0F5E2C5BE285007812C5 /* OpenTalkPageType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenTalkPageType.swift; sourceTree = "<group>"; };
 		AB0C0F602C5BE9B1007812C5 /* ChatViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewController.swift; sourceTree = "<group>"; };
@@ -671,6 +672,7 @@
 		AB22AD3A2C4E8D9D00C9A0F3 /* BookTalk */ = {
 			isa = PBXGroup;
 			children = (
+				AB0784862C74FF2C0017812F /* BookTalk.entitlements */,
 				AB22AD492C4E8D9F00C9A0F3 /* Info.plist */,
 				057925182C4F927C00834EC6 /* Resources */,
 				057925172C4F927100834EC6 /* Sources */,
@@ -1430,9 +1432,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				BASE_URL = "http://52.79.187.133:8080";
+				CODE_SIGN_ENTITLEMENTS = BookTalk/BookTalk.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = BTX96P3YD4;
+				DEVELOPMENT_TEAM = U6TKDM29D9;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = BookTalk/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.books";
@@ -1467,9 +1470,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				BASE_URL = "http://52.79.187.133:8080";
+				CODE_SIGN_ENTITLEMENTS = BookTalk/BookTalk.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = BTX96P3YD4;
+				DEVELOPMENT_TEAM = U6TKDM29D9;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = BookTalk/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.books";

--- a/BookTalk/BookTalk.xcodeproj/project.pbxproj
+++ b/BookTalk/BookTalk.xcodeproj/project.pbxproj
@@ -50,6 +50,8 @@
 		0579D1142C6C9F8C0032AC1C /* KeywordCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0579D1132C6C9F8C0032AC1C /* KeywordCell.swift */; };
 		0579D1162C6C9FA30032AC1C /* KeywordCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0579D1152C6C9FA30032AC1C /* KeywordCollectionCell.swift */; };
 		0579D1182C6C9FC30032AC1C /* KeywordViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0579D1172C6C9FC30032AC1C /* KeywordViewModel.swift */; };
+		AB0784812C74F8910017812F /* KakaoSDKAuth in Frameworks */ = {isa = PBXBuildFile; productRef = AB0784802C74F8910017812F /* KakaoSDKAuth */; };
+		AB0784832C74F8910017812F /* KakaoSDKUser in Frameworks */ = {isa = PBXBuildFile; productRef = AB0784822C74F8910017812F /* KakaoSDKUser */; };
 		AB0C0F592C5BD98B007812C5 /* OpenTalkPageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0C0F582C5BD98B007812C5 /* OpenTalkPageCell.swift */; };
 		AB0C0F5F2C5BE285007812C5 /* OpenTalkPageType.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0C0F5E2C5BE285007812C5 /* OpenTalkPageType.swift */; };
 		AB0C0F612C5BE9B1007812C5 /* ChatViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0C0F602C5BE9B1007812C5 /* ChatViewController.swift */; };
@@ -275,9 +277,11 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AB0784812C74F8910017812F /* KakaoSDKAuth in Frameworks */,
 				AB22AD512C4E92C100C9A0F3 /* SnapKit in Frameworks */,
 				AB4CBA592C6BADD3009A2AB6 /* Alamofire in Frameworks */,
 				ABED440D2C66549E0073398A /* DGCharts in Frameworks */,
+				AB0784832C74F8910017812F /* KakaoSDKUser in Frameworks */,
 				AB22AD542C4E92C700C9A0F3 /* Then in Frameworks */,
 				AB4ECF462C70848C00DC24A0 /* Kingfisher in Frameworks */,
 				054FA16E2C7463D40007D9C9 /* Lottie in Frameworks */,
@@ -1091,6 +1095,8 @@
 				AB4CBA582C6BADD3009A2AB6 /* Alamofire */,
 				AB4ECF452C70848C00DC24A0 /* Kingfisher */,
 				054FA16D2C7463D40007D9C9 /* Lottie */,
+				AB0784802C74F8910017812F /* KakaoSDKAuth */,
+				AB0784822C74F8910017812F /* KakaoSDKUser */,
 			);
 			productName = BookTalk;
 			productReference = AB22AD382C4E8D9D00C9A0F3 /* BookTalk.app */;
@@ -1127,6 +1133,7 @@
 				AB4CBA572C6BADD3009A2AB6 /* XCRemoteSwiftPackageReference "Alamofire" */,
 				AB4ECF442C70848C00DC24A0 /* XCRemoteSwiftPackageReference "Kingfisher" */,
 				054FA16C2C7463D40007D9C9 /* XCRemoteSwiftPackageReference "lottie-ios" */,
+				AB07847F2C74F8910017812F /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */,
 			);
 			productRefGroup = AB22AD392C4E8D9D00C9A0F3 /* Products */;
 			projectDirPath = "";
@@ -1519,6 +1526,14 @@
 				minimumVersion = 4.5.0;
 			};
 		};
+		AB07847F2C74F8910017812F /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/kakao/kakao-ios-sdk";
+			requirement = {
+				branch = master;
+				kind = branch;
+			};
+		};
 		AB22AD4F2C4E92C100C9A0F3 /* XCRemoteSwiftPackageReference "SnapKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SnapKit/SnapKit";
@@ -1566,6 +1581,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 054FA16C2C7463D40007D9C9 /* XCRemoteSwiftPackageReference "lottie-ios" */;
 			productName = Lottie;
+		};
+		AB0784802C74F8910017812F /* KakaoSDKAuth */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = AB07847F2C74F8910017812F /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKAuth;
+		};
+		AB0784822C74F8910017812F /* KakaoSDKUser */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = AB07847F2C74F8910017812F /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKUser;
 		};
 		AB22AD502C4E92C100C9A0F3 /* SnapKit */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/BookTalk/BookTalk.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/BookTalk/BookTalk.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "421059cd82b5f4e6950d803730d1a69806287d8aa82dad4368915d6dd7543e0e",
+  "originHash" : "e2bdf8c3b39c1510e48f5c29cffbd0933a2b986e6076b6f28d0100c591521d1c",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -17,6 +17,15 @@
       "state" : {
         "revision" : "dd9c72e3d7e751e769971092a6bd72d39198ae63",
         "version" : "5.1.0"
+      }
+    },
+    {
+      "identity" : "kakao-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kakao/kakao-ios-sdk",
+      "state" : {
+        "branch" : "master",
+        "revision" : "66b3bddc2657e8ccb7a16fa0264aac99c57be09b"
       }
     },
     {

--- a/BookTalk/BookTalk/BookTalk.entitlements
+++ b/BookTalk/BookTalk/BookTalk.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/BookTalk/BookTalk/Info.plist
+++ b/BookTalk/BookTalk/Info.plist
@@ -2,13 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>BASE_URL</key>
+	<string>$(BASE_URL)</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
-	<key>BASE_URL</key>
-	<string>$(BASE_URL)</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/BookTalk/BookTalk/Info.plist
+++ b/BookTalk/BookTalk/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>KakaoNativeAppKey</key>
+	<string>d3ddedc9b13b7bf5d046bd16a67e1e5c</string>
 	<key>BASE_URL</key>
 	<string>$(BASE_URL)</string>
 	<key>CFBundleURLTypes</key>

--- a/BookTalk/BookTalk/Info.plist
+++ b/BookTalk/BookTalk/Info.plist
@@ -4,6 +4,17 @@
 <dict>
 	<key>BASE_URL</key>
 	<string>$(BASE_URL)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>kakaod3ddedc9b13b7bf5d046bd16a67e1e5c</string>
+			</array>
+		</dict>
+	</array>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>

--- a/BookTalk/BookTalk/Sources/Application/AppDelegate.swift
+++ b/BookTalk/BookTalk/Sources/Application/AppDelegate.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+import KakaoSDKCommon
+
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
     
@@ -14,6 +16,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
+        KakaoSDK.initSDK(appKey: Constant.kakaoKey)
+
         return true
     }
     

--- a/BookTalk/BookTalk/Sources/Application/SceneDelegate.swift
+++ b/BookTalk/BookTalk/Sources/Application/SceneDelegate.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+import KakaoSDKAuth
+
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     var window: UIWindow?
@@ -23,7 +25,18 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         AppFlowController.shared.show(in: window)
     }
-    
+
+    func scene(
+        _ scene: UIScene,
+        openURLContexts URLContexts: Set<UIOpenURLContext>
+    ) {
+        if let url = URLContexts.first?.url {
+            if (AuthApi.isKakaoTalkLoginUrl(url)) {
+                _ = AuthController.handleOpenUrl(url: url)
+            }
+        }
+    }
+
     func sceneDidDisconnect(_ scene: UIScene) {
     }
     

--- a/BookTalk/BookTalk/Sources/Presentation/Component/SocialLoginButton.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Component/SocialLoginButton.swift
@@ -41,6 +41,7 @@ final class SocialLoginButton: UIButton {
                 authorizationButtonStyle: .black
             )
             self.addSubview(apple)
+
             self.do {
                 $0.appleLoginButton = apple
             }

--- a/BookTalk/BookTalk/Sources/Presentation/Login/Manager/OAuthManager.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Login/Manager/OAuthManager.swift
@@ -1,0 +1,40 @@
+//
+//  OAuthManager.swift
+//  BookTalk
+//
+//  Created by 김민 on 8/21/24.
+//
+
+import Foundation
+
+import KakaoSDKUser
+
+final class OAuthManager {
+
+    func loginWithKakao() {
+        
+        if (UserApi.isKakaoTalkLoginAvailable()) {
+            UserApi.shared.loginWithKakaoTalk {(oauthToken, error) in
+                if let error = error {
+                    print(error)
+                }
+                else {
+                    print("loginWithKakaoTalk() success.")
+
+                    _ = oauthToken
+                }
+            }
+        } else {
+            UserApi.shared.loginWithKakaoAccount {(oauthToken, error) in
+                if let error = error {
+                    print(error)
+                }
+                else {
+                    print("loginWithKakaoAccount() success.")
+
+                    _ = oauthToken
+                }
+            }
+        }
+    }
+}

--- a/BookTalk/BookTalk/Sources/Presentation/Login/Manager/OAuthManager.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Login/Manager/OAuthManager.swift
@@ -5,11 +5,14 @@
 //  Created by 김민 on 8/21/24.
 //
 
+import AuthenticationServices
 import Foundation
 
 import KakaoSDKUser
 
-final class OAuthManager {
+final class OAuthManager: NSObject {
+
+    var appleLoginSucceed: ((ASAuthorizationAppleIDCredential) -> Void)?
 
     func loginWithKakao() {
         
@@ -36,5 +39,48 @@ final class OAuthManager {
                 }
             }
         }
+    }
+
+    func loginWithApple() {
+        let request = ASAuthorizationAppleIDProvider().createRequest()
+        request.requestedScopes = [.fullName, .email]
+
+        let authorizationController = ASAuthorizationController(authorizationRequests: [request])
+        authorizationController.delegate = self
+        authorizationController.presentationContextProvider = self
+        authorizationController.performRequests()
+    }
+}
+
+extension OAuthManager: ASAuthorizationControllerDelegate {
+
+    func authorizationController(
+        controller: ASAuthorizationController,
+        didCompleteWithAuthorization authorization: ASAuthorization
+    ) {
+        guard let credential = authorization.credential
+                as? ASAuthorizationAppleIDCredential else { return }
+
+        appleLoginSucceed?(credential)
+    }
+
+    func authorizationController(
+        controller: ASAuthorizationController,
+        didCompleteWithError error: Error
+    ) {
+        print(error.localizedDescription)
+        // TODO: 애플 로그인 실패 시 에러 처리
+    }
+}
+
+extension OAuthManager: ASAuthorizationControllerPresentationContextProviding {
+
+    func presentationAnchor(
+        for controller: ASAuthorizationController
+    ) -> ASPresentationAnchor {
+        let scenes = UIApplication.shared.connectedScenes
+        let windowScene = scenes.first as? UIWindowScene
+
+        return windowScene?.windows.first ?? UIWindow()
     }
 }

--- a/BookTalk/BookTalk/Sources/Presentation/Login/View/LoginViewController.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Login/View/LoginViewController.swift
@@ -19,10 +19,16 @@ final class LoginViewController: BaseViewController {
     private let onboardingLabel = UILabel()
     private let waveView = WaveView()
     private let animationView: LottieAnimationView = .init(name: "login")
-    private let appleLoginButton = SocialLoginButton(type: .apple)
-    private let kakaoLoginButton = SocialLoginButton(type: .kakao)
+//    private let appleLoginButton = SocialLoginButton(type: .apple)
+//    private let kakaoLoginButton = SocialLoginButton(type: .kakao)
     private let loginButtons = UIStackView()
-    
+
+    private let appleLoginButton = ASAuthorizationAppleIDButton(
+        authorizationButtonType: .signIn,
+        authorizationButtonStyle: .black
+    )
+    private let kakaoLoginButton = UIButton()
+
     // MARK: - Lifecycle
     
     override func viewDidLoad() {
@@ -49,8 +55,16 @@ final class LoginViewController: BaseViewController {
     }
     
     private func addTargets() {
-        appleLoginButton.addTarget(self, action: #selector(appleLoginTapped), for: .touchUpInside)
-        kakaoLoginButton.addTarget(self, action: #selector(kakaoLoginTapped), for: .touchUpInside)
+        appleLoginButton.addTarget(
+            self,
+            action: #selector(appleLoginTapped),
+            for: .touchUpInside
+        )
+        kakaoLoginButton.addTarget(
+            self,
+            action: #selector(kakaoLoginTapped),
+            for: .touchUpInside
+        )
     }
     
     // MARK: - Bind
@@ -104,9 +118,17 @@ final class LoginViewController: BaseViewController {
             $0.isLayoutMarginsRelativeArrangement = true
             $0.layoutMargins = .init(top: 0, left: 20, bottom: 0, right: 20)
         }
+
+        kakaoLoginButton.do {
+            $0.setBackgroundImage(UIImage(named: "kakaoLoginButton"), for: .normal)
+        }
     }
     
     override func setConstraints() {
+        [appleLoginButton, kakaoLoginButton].forEach {
+            loginButtons.addArrangedSubview($0)
+        }
+
         [progressView, onboardingLabel, waveView, animationView, loginButtons].forEach {
             view.addSubview($0)
         }
@@ -136,7 +158,15 @@ final class LoginViewController: BaseViewController {
             $0.left.equalToSuperview()
             $0.height.equalTo(animationView.snp.width)
         }
-        
+
+        appleLoginButton.snp.makeConstraints {
+            $0.height.equalTo(50)
+        }
+
+        kakaoLoginButton.snp.makeConstraints {
+            $0.height.equalTo(50)
+        }
+
         loginButtons.snp.makeConstraints {
             $0.centerX.left.equalToSuperview()
             $0.bottom.equalTo(view.snp.bottom)

--- a/BookTalk/BookTalk/Sources/Presentation/Login/View/LoginViewController.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Login/View/LoginViewController.swift
@@ -45,12 +45,7 @@ final class LoginViewController: BaseViewController {
     }
     
     @objc private func kakaoLoginTapped() {
-        // TODO: 로그인 로직 구현 후 삭제
-        UserDefaults.standard.setValue(true, forKey: UserDefaults.Key.isLoggedIn)
-        NotificationCenter.default.post(
-            name: Notification.Name.authStateChanged,
-            object: nil
-        )
+        viewModel.input.loginButtonTapped(.kakao)
     }
     
     private func addTargets() {

--- a/BookTalk/BookTalk/Sources/Presentation/Login/View/LoginViewController.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Login/View/LoginViewController.swift
@@ -19,8 +19,6 @@ final class LoginViewController: BaseViewController {
     private let onboardingLabel = UILabel()
     private let waveView = WaveView()
     private let animationView: LottieAnimationView = .init(name: "login")
-//    private let appleLoginButton = SocialLoginButton(type: .apple)
-//    private let kakaoLoginButton = SocialLoginButton(type: .kakao)
     private let loginButtons = UIStackView()
 
     private let appleLoginButton = ASAuthorizationAppleIDButton(

--- a/BookTalk/BookTalk/Sources/Presentation/Login/ViewModel/LoginViewModel.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Login/ViewModel/LoginViewModel.swift
@@ -21,12 +21,15 @@ final class LoginViewModel {
     }
     
     // MARK: - Properties
-    
+
+    private let oauthManager = OAuthManager()
+
     let onboardingMessageManager: OnboardingManager
     
     lazy var input: Input = { bindInput() }()
     lazy var output: Output = { transform() }()
-    
+
+
     // MARK: - Initializer
     
     init(onboardingMessageManager:
@@ -41,6 +44,7 @@ final class LoginViewModel {
     ) {
         self.onboardingMessageManager = onboardingMessageManager
         setupBindings()
+
         onboardingMessageManager.startRotation()
     }
     
@@ -69,7 +73,14 @@ final class LoginViewModel {
     }
     
     private func handleLogin(type: LoginType) {
+        switch type {
+        case .apple:
+            // TODO:
+            return
 
+        case .kakao:
+            oauthManager.loginWithKakao()
+        }
     }
     
     func cleanupTimers() {

--- a/BookTalk/BookTalk/Sources/Presentation/Login/ViewModel/LoginViewModel.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Login/ViewModel/LoginViewModel.swift
@@ -75,8 +75,12 @@ final class LoginViewModel {
     private func handleLogin(type: LoginType) {
         switch type {
         case .apple:
-            // TODO:
-            return
+            oauthManager.loginWithApple()
+
+            oauthManager.appleLoginSucceed = { credential in
+                print(credential)
+                // TODO: API 호출
+            }
 
         case .kakao:
             oauthManager.loginWithKakao()

--- a/BookTalk/BookTalk/Sources/Util/Constant.swift
+++ b/BookTalk/BookTalk/Sources/Util/Constant.swift
@@ -29,3 +29,19 @@ extension Constant {
         return "v.0.0"
     }
 }
+
+extension Constant {
+
+    static var kakaoKey: String {
+        guard let filePath = Bundle.main.path(forResource: "Info", ofType: "plist"),
+              let plistDict = NSDictionary(contentsOfFile: filePath) else {
+            fatalError("plist 파일 찾을 수 없음")
+        }
+
+        guard let value = plistDict.object(forKey: "KakaoNativeAppKey") as? String else {
+            fatalError("key값 찾을 수 없음")
+        }
+
+        return value
+    }
+}


### PR DESCRIPTION
## 📚 PR 요약
카카오 로그인 / 애플 로그인 기본 세팅

## 📝 작업 내용
- 필요한 sdk 설치
- 애플 로그인: credential 얻는 곳까지 구현
- 카카오 로그인: 카카오 자체 로그인까지만 구현

## 📌 참고 사항
- 둘다 아직 api 연결은 안 됐습니다!
- 뷰모델에서 진행할 로직은 아닌 것 같아서 `oAuthManager` 로 분리했는데, 카카오와 애플로 구분하는 것도 고려하고 있습니다.

## 📮 관련 이슈
- Resolved: #89 
