### PR TITLE
[feat] 회원가입 UI 구현

### DIFF
--- a/BookTalk/BookTalk.xcodeproj/project.pbxproj
+++ b/BookTalk/BookTalk.xcodeproj/project.pbxproj
@@ -57,6 +57,8 @@
 		0579D1142C6C9F8C0032AC1C /* KeywordCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0579D1132C6C9F8C0032AC1C /* KeywordCell.swift */; };
 		0579D1162C6C9FA30032AC1C /* KeywordCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0579D1152C6C9FA30032AC1C /* KeywordCollectionCell.swift */; };
 		0579D1182C6C9FC30032AC1C /* KeywordViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0579D1172C6C9FC30032AC1C /* KeywordViewModel.swift */; };
+		05CB069C2C7699E100673947 /* RegistrationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05CB069B2C7699E100673947 /* RegistrationViewModel.swift */; };
+		05CB069E2C769A1700673947 /* RegistrationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05CB069D2C769A1700673947 /* RegistrationViewController.swift */; };
 		AB0784812C74F8910017812F /* KakaoSDKAuth in Frameworks */ = {isa = PBXBuildFile; productRef = AB0784802C74F8910017812F /* KakaoSDKAuth */; };
 		AB0784832C74F8910017812F /* KakaoSDKUser in Frameworks */ = {isa = PBXBuildFile; productRef = AB0784822C74F8910017812F /* KakaoSDKUser */; };
 		AB0784852C74FA1D0017812F /* OAuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0784842C74FA1D0017812F /* OAuthManager.swift */; };
@@ -200,6 +202,8 @@
 		0579D1132C6C9F8C0032AC1C /* KeywordCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeywordCell.swift; sourceTree = "<group>"; };
 		0579D1152C6C9FA30032AC1C /* KeywordCollectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeywordCollectionCell.swift; sourceTree = "<group>"; };
 		0579D1172C6C9FC30032AC1C /* KeywordViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeywordViewModel.swift; sourceTree = "<group>"; };
+		05CB069B2C7699E100673947 /* RegistrationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationViewModel.swift; sourceTree = "<group>"; };
+		05CB069D2C769A1700673947 /* RegistrationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationViewController.swift; sourceTree = "<group>"; };
 		AB0784842C74FA1D0017812F /* OAuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthManager.swift; sourceTree = "<group>"; };
 		AB0784862C74FF2C0017812F /* BookTalk.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = BookTalk.entitlements; sourceTree = "<group>"; };
 		AB0C0F582C5BD98B007812C5 /* OpenTalkPageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenTalkPageCell.swift; sourceTree = "<group>"; };
@@ -575,6 +579,7 @@
 			isa = PBXGroup;
 			children = (
 				054FA16F2C7464120007D9C9 /* Login */,
+				05CB06982C7699CD00673947 /* Registration */,
 				056F2FEE2C5B4E3600931302 /* MainTab */,
 				056F30472C60D4E400931302 /* BookDetail */,
 				0545432E2C53725200E64948 /* Home */,
@@ -594,6 +599,31 @@
 				0579D10F2C6C9E410032AC1C /* HomeSectionType.swift */,
 			);
 			path = Enum;
+			sourceTree = "<group>";
+		};
+		05CB06982C7699CD00673947 /* Registration */ = {
+			isa = PBXGroup;
+			children = (
+				05CB069A2C7699D900673947 /* View */,
+				05CB06992C7699D400673947 /* ViewModel */,
+			);
+			path = Registration;
+			sourceTree = "<group>";
+		};
+		05CB06992C7699D400673947 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				05CB069B2C7699E100673947 /* RegistrationViewModel.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		05CB069A2C7699D900673947 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				05CB069D2C769A1700673947 /* RegistrationViewController.swift */,
+			);
+			path = View;
 			sourceTree = "<group>";
 		};
 		AB0C0F552C5BD557007812C5 /* OpenTalk */ = {
@@ -1298,6 +1328,7 @@
 				054543F22C5A233600E64948 /* SearchMockData.swift in Sources */,
 				051155F12C64B08F00230CFE /* ReusableIdentifier.swift in Sources */,
 				AB2E7BCE2C53ADF700CE43CB /* BaseViewController.swift in Sources */,
+				05CB069E2C769A1700673947 /* RegistrationViewController.swift in Sources */,
 				0579253F2C4FF4D700834EC6 /* OpenTalkViewController.swift in Sources */,
 				AB4CBA4D2C6B2E4B009A2AB6 /* ChatMenuViewModel.swift in Sources */,
 				054FA1982C748E9F0007D9C9 /* EditLibraryViewController.swift in Sources */,
@@ -1311,6 +1342,7 @@
 				AB2E7BC12C525CC700CE43CB /* CategoryType.swift in Sources */,
 				AB2E7BFE2C5602A500CE43CB /* Category.swift in Sources */,
 				AB4CBA782C6E037B009A2AB6 /* SettingCell.swift in Sources */,
+				05CB069C2C7699E100673947 /* RegistrationViewModel.swift in Sources */,
 				ABB901C42C73980600727875 /* OpenTalkResponseDTO.swift in Sources */,
 				AB0C0F672C5BFC53007812C5 /* MyChatBubbleCell.swift in Sources */,
 				AB0C0F612C5BE9B1007812C5 /* ChatViewController.swift in Sources */,

--- a/BookTalk/BookTalk/Info.plist
+++ b/BookTalk/BookTalk/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>앨범 접근 권한이 필요합니다.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>카메라 접근 권한이 필요합니다.</string>
 	<key>KakaoNativeAppKey</key>
 	<string>d3ddedc9b13b7bf5d046bd16a67e1e5c</string>
 	<key>BASE_URL</key>

--- a/BookTalk/BookTalk/Sources/Presentation/Registration/View/RegistrationViewController.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Registration/View/RegistrationViewController.swift
@@ -1,0 +1,433 @@
+//
+//  RegistrationViewController.swift
+//  BookTalk
+//
+//  Created by RAFA on 8/22/24.
+//
+
+import UIKit
+
+final class RegistrationViewController: BaseViewController {
+    
+    // MARK: - Properties
+    
+    private var viewModel = RegistrationViewModel()
+    private var isKeyboardAlreadyShown = false
+    
+    private let addPhotoButton = UIButton(type: .system)
+    private let nicknameTextField = UITextField()
+    private let maleButton = UIButton(type: .system)
+    private let femaleButton = UIButton(type: .system)
+    private let selectGenderButtonStackView = UIStackView()
+    private let birthTextField = UITextField()
+    private let datePicker = UIDatePicker()
+    private let signUpButton = UIButton(type: .system)
+    private let credentialsStackView = UIStackView()
+    
+    // MARK: - Lifecycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        addTargets()
+        bind()
+        registerKeyboardNotifications()
+        setToolBar()
+    }
+    
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        view.endEditing(true)
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+    
+    // MARK: - Actions
+    
+    @objc private func addPhotoButtonTapped() {
+        presentImagePickerActionSheet()
+    }
+    
+    @objc private func nicknameChanged() {
+        viewModel.updateNickname(nicknameTextField.text ?? "")
+    }
+    
+    @objc private func selectMaleGender() {
+        viewModel.updateGender(.male)
+    }
+
+    @objc private func selectFemaleGender() {
+        viewModel.updateGender(.female)
+    }
+    
+    @objc private func dateChanged(_ sender: UIDatePicker) {
+        viewModel.updateBirthDate(sender.date)
+    }
+    
+    @objc func doneButtonHandler() {
+        birthTextField.attributedText = dateFormat(date: datePicker.date)
+        viewModel.updateBirthDate(datePicker.date)
+        birthTextField.resignFirstResponder()
+    }
+
+    @objc private func keyboardWillShow(_ notification: Notification) {
+        if !isKeyboardAlreadyShown {
+            UIView.animate(withDuration: 0.3) {
+                self.view.backgroundColor = .black.withAlphaComponent(0.8)
+                self.addPhotoButton.alpha = 0.2
+                self.view.bringSubviewToFront(self.credentialsStackView)
+            }
+            isKeyboardAlreadyShown = true
+        }
+    }
+
+    @objc private func keyboardWillHide(_ notification: Notification) {
+        UIView.animate(withDuration: 0.3) {
+            self.view.backgroundColor = .white
+            self.addPhotoButton.alpha = 1
+        }
+        isKeyboardAlreadyShown = false
+    }
+    
+    private func registerKeyboardNotifications() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(keyboardWillShow),
+            name: UIResponder.keyboardWillShowNotification,
+            object: nil
+        )
+        
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(keyboardWillHide),
+            name: UIResponder.keyboardWillHideNotification,
+            object: nil
+        )
+    }
+    
+    private func addTargets() {
+        addPhotoButton.addTarget(self, action: #selector(addPhotoButtonTapped), for: .touchUpInside)
+        nicknameTextField.addTarget(self, action: #selector(nicknameChanged), for: .editingChanged)
+        maleButton.addTarget(self, action: #selector(selectMaleGender), for: .touchUpInside)
+        femaleButton.addTarget(self, action: #selector(selectFemaleGender), for: .touchUpInside)
+        datePicker.addTarget(self, action: #selector(dateChanged), for: .valueChanged)
+    }
+    
+    // MARK: - Bind
+    
+    private func bind() {
+        viewModel.nickname.subscribe { [weak self] _ in
+            self?.nicknameTextField.text = self?.viewModel.nickname.value
+        }
+        
+        viewModel.selectedGender.subscribe { [weak self] gender in
+            self?.updateGenderSelection(gender)
+        }
+        
+        viewModel.birthDate.subscribe { [weak self] date in
+            self?.birthTextField.attributedText = self?.dateFormat(date: date)
+        }
+        
+        viewModel.isFormValid.subscribe { [weak self] isValid in
+            self?.updateSignUpButtonState(isValid: isValid)
+        }
+    }
+    
+    // MARK: - Helpers
+    
+    private func updateGenderSelection(_ gender: Gender?) {
+        maleButton.backgroundColor = gender == .male ?
+            .accentOrange : .accentOrange.withAlphaComponent(0.2)
+        femaleButton.backgroundColor = gender ==
+            .female ? .accentOrange : .accentOrange.withAlphaComponent(0.2)
+    }
+    
+    private func dateFormat(date: Date?) -> NSAttributedString {
+        if let date = date {
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yyyy년 MM월 dd일"
+            let dateString = formatter.string(from: date)
+            return NSAttributedString(
+                string: dateString,
+                attributes: [.foregroundColor: UIColor.label]
+            )
+        } else {
+            return NSAttributedString(
+                string: "생일을 선택해주세요.",
+                attributes: [.foregroundColor: UIColor.gray100]
+            )
+        }
+    }
+    
+    private func updateSignUpButtonState(isValid: Bool) {
+        UIView.animate(withDuration: 0.3) {
+            self.signUpButton.isEnabled = isValid
+            self.signUpButton.backgroundColor = isValid ? 
+                .accentOrange : .accentOrange.withAlphaComponent(0.2)
+            self.signUpButton.setTitleColor(
+                isValid ? .white : .systemBackground.withAlphaComponent(0.7),
+                for: .normal
+            )
+        }
+    }
+    
+    // MARK: - Set UI
+    
+    override func setNavigationBar() {
+        navigationController?.navigationBar.topItem?.title = "정보 등록"
+    }
+    
+    override func setViews() {
+        addPhotoButton.do {
+            $0.setImage(
+                UIImage(systemName: "plus")?
+                    .withTintColor(.systemBlue, renderingMode: .alwaysOriginal)
+                    .withConfiguration(
+                        UIImage.SymbolConfiguration(pointSize: 30, weight: .light)
+                    ),
+                for: .normal
+            )
+            $0.layer.cornerRadius = 180 / 2
+            $0.layer.masksToBounds = true
+            $0.layer.borderWidth = 1
+            $0.layer.borderColor = UIColor.accentOrange.cgColor
+        }
+        
+        setupTextField(
+            textField: nicknameTextField,
+            placeholder: "닉네임 (한글 2자 이상, 영어 3자 이상)",
+            spacerWidth: 12
+        )
+        
+        setupGenderButton(maleButton, title: "남")
+        setupGenderButton(femaleButton, title: "여")
+        
+        selectGenderButtonStackView.do {
+            $0.addArrangedSubview(maleButton)
+            $0.addArrangedSubview(femaleButton)
+            $0.axis = .horizontal
+            $0.alignment = .fill
+            $0.distribution = .fillEqually
+            $0.spacing = 5
+        }
+        
+        setupTextField(
+            textField: birthTextField,
+            spacerWidth: 12
+        )
+        
+        birthTextField.do {
+            $0.tintColor = .clear
+            $0.inputView = datePicker
+            $0.delegate = self
+        }
+        
+        datePicker.do {
+            $0.datePickerMode = .date
+            $0.preferredDatePickerStyle = .wheels
+            $0.locale = .init(identifier: "ko-KR")
+        }
+        
+        signUpButton.do {
+            $0.isEnabled = false
+            $0.layer.cornerRadius = 10
+            $0.setTitle("정보 등록하기", for: .normal)
+            $0.setTitleColor(.white.withAlphaComponent(0.7), for: .normal)
+            $0.backgroundColor = .accentOrange.withAlphaComponent(0.8)
+        }
+        
+        credentialsStackView.do {
+            $0.addArrangedSubview(nicknameTextField)
+            $0.addArrangedSubview(selectGenderButtonStackView)
+            $0.addArrangedSubview(birthTextField)
+            $0.addArrangedSubview(signUpButton)
+            $0.axis = .vertical
+            $0.spacing = 10
+        }
+    }
+    
+    override func setConstraints() {
+        [addPhotoButton,
+         credentialsStackView].forEach { view.addSubview($0) }
+        
+        addPhotoButton.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(20)
+            $0.size.equalTo(180)
+        }
+        
+        nicknameTextField.snp.makeConstraints {
+            $0.height.equalTo(50)
+        }
+        
+        maleButton.snp.makeConstraints {
+            $0.height.equalTo(50)
+        }
+        
+        credentialsStackView.snp.makeConstraints {
+            $0.centerX.equalTo(addPhotoButton)
+            $0.top.lessThanOrEqualTo(addPhotoButton.snp.bottom).offset(20)
+            $0.left.equalTo(10)
+            $0.bottom.equalTo(view.keyboardLayoutGuide.snp.top).offset(-20)
+        }
+        
+        birthTextField.snp.makeConstraints {
+            $0.height.equalTo(50)
+        }
+        
+        signUpButton.snp.makeConstraints {
+            $0.height.equalTo(50)
+        }
+    }
+}
+
+// MARK: - UIImagePickerControllerDelegate
+
+extension RegistrationViewController: UIImagePickerControllerDelegate {
+    
+    func imagePickerController(
+        _ picker: UIImagePickerController,
+        didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]
+    ) {
+        if let editedImage = info[.editedImage] as? UIImage {
+            addPhotoButton.setImage(
+                editedImage.withRenderingMode(.alwaysOriginal),
+                for: .normal
+            )
+        } else if let originalImage = info[.originalImage] as? UIImage {
+            addPhotoButton.setImage(
+                originalImage.withRenderingMode(.alwaysOriginal),
+                for: .normal
+            )
+        }
+        
+        addPhotoButton.layer.borderColor = UIColor.clear.cgColor
+        addPhotoButton.contentMode = .scaleAspectFill
+        dismiss(animated: true, completion: nil)
+    }
+    
+    func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+        dismiss(animated: true, completion: nil)
+    }
+}
+
+// MARK: - UINavigationControllerDelegate
+
+extension RegistrationViewController: UINavigationControllerDelegate {
+    
+    private func presentImagePickerActionSheet() {
+        let actionSheet = UIAlertController(
+            title: "사진 선택",
+            message: "프로필 사진을 선택하세요.",
+            preferredStyle: .actionSheet
+        )
+        
+        let cameraAction = UIAlertAction(title: "카메라", style: .default) { _ in
+            self.presentImagePicker(sourceType: .camera)
+        }
+        
+        let libraryAction = UIAlertAction(title: "사진 앨범", style: .default) { _ in
+            self.presentImagePicker(sourceType: .photoLibrary)
+        }
+        
+        let cancelAction = UIAlertAction(title: "취소", style: .cancel, handler: nil)
+        
+        actionSheet.addAction(cameraAction)
+        actionSheet.addAction(libraryAction)
+        actionSheet.addAction(cancelAction)
+        
+        present(actionSheet, animated: true, completion: nil)
+    }
+    
+    private func presentImagePicker(sourceType: UIImagePickerController.SourceType) {
+        guard UIImagePickerController.isSourceTypeAvailable(sourceType) else { return }
+        
+        let imagePicker = UIImagePickerController()
+        imagePicker.sourceType = sourceType
+        imagePicker.delegate = self
+        imagePicker.allowsEditing = true
+        
+        present(imagePicker, animated: true, completion: nil)
+    }
+}
+
+// MARK: - UITextFieldDelegate
+
+extension RegistrationViewController: UITextFieldDelegate {
+    
+    func textField(
+        _ textField: UITextField,
+        shouldChangeCharactersIn range: NSRange,
+        replacementString string: String
+    ) -> Bool {
+        return false
+    }
+}
+
+// MARK: - Set UI Helpers
+
+private extension RegistrationViewController {
+
+    func setupTextField(textField: UITextField, placeholder: String? = nil, spacerWidth: CGFloat) {
+        textField.do {
+            $0.textColor = .label
+            $0.tintColor = .label
+            $0.borderStyle = .none
+            $0.layer.borderWidth = 1
+            $0.layer.borderColor = UIColor.gray100.cgColor
+            $0.layer.cornerRadius = 10
+            $0.backgroundColor = .white
+            $0.spellCheckingType = .no
+            $0.autocorrectionType = .no
+            $0.autocapitalizationType = .none
+            let spacer = UIView(frame: .init(x: 0, y: 0, width: spacerWidth, height: 50))
+            $0.leftView = spacer
+            $0.leftViewMode = .always
+            if let placeholder = placeholder {
+                $0.attributedPlaceholder = NSAttributedString(
+                    string: placeholder,
+                    attributes: [.foregroundColor: UIColor.gray100]
+                )
+            }
+        }
+    }
+
+    func setupGenderButton(_ button: UIButton, title: String) {
+        button.do {
+            $0.setAttributedTitle(
+                NSAttributedString(
+                    string: title,
+                    attributes: [
+                        .font: UIFont.systemFont(ofSize: 15, weight: .medium),
+                        .foregroundColor: UIColor.white
+                    ]
+                ),
+                for: .normal
+            )
+            $0.clipsToBounds = true
+            $0.layer.cornerRadius = 10
+        }
+    }
+    
+    func setToolBar() {
+        let toolBar = UIToolbar()
+        
+        let flexibleSpace = UIBarButtonItem(
+            barButtonSystemItem: .flexibleSpace,
+            target: nil,
+            action: nil
+        )
+        
+        let doneButton = UIBarButtonItem(
+            barButtonSystemItem: .done,
+            target: self,
+            action: #selector(doneButtonHandler)
+        )
+        
+        toolBar.items = [flexibleSpace, doneButton]
+        toolBar.sizeToFit()
+        
+        birthTextField.inputAccessoryView = toolBar
+    }
+}

--- a/BookTalk/BookTalk/Sources/Presentation/Registration/ViewModel/RegistrationViewModel.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Registration/ViewModel/RegistrationViewModel.swift
@@ -1,0 +1,62 @@
+//
+//  RegistrationViewModel.swift
+//  BookTalk
+//
+//  Created by RAFA on 8/22/24.
+//
+
+import UIKit
+
+enum Gender {
+    case male, female
+}
+
+struct RegistrationViewModel {
+    
+    // MARK: - Inputs
+    
+    let nickname = Observable<String>("")
+    let selectedGender = Observable<Gender?>(nil)
+    let birthDate = Observable<Date?>(nil)
+    let isFormValid = Observable<Bool>(false)
+    
+    // MARK: - Actions
+    
+    func updateNickname(_ text: String) {
+        nickname.value = text
+        validateForm()
+    }
+    
+    func updateGender(_ gender: Gender) {
+        selectedGender.value = gender
+        validateForm()
+    }
+    
+    func updateBirthDate(_ date: Date?) {
+        birthDate.value = date
+        validateForm()
+    }
+    
+    // MARK: - Helpers
+    
+    private func validateForm() {
+        isFormValid.value =
+            isNicknameValid() && selectedGender.value != nil && birthDate.value != nil
+    }
+    
+    private func isNicknameValid() -> Bool {
+        guard !nickname.value.isEmpty else { return false }
+        
+        if isKorean(nickname.value) {
+            return nickname.value.count >= 2
+        } else {
+            return nickname.value.count >= 3
+        }
+    }
+    
+    private func isKorean(_ text: String) -> Bool {
+        let koreanRegex = "^[가-힣]*$"
+        let koreanPredicate = NSPredicate(format: "SELF MATCHES %@", koreanRegex)
+        return koreanPredicate.evaluate(with: text)
+    }
+}


### PR DESCRIPTION
## 📚 PR 요약
회원가입 UI 구현

## 📝 작업 내용
- 프로필 이미지 등록 버튼 구현
- 이미지 피커 구현
- 닉네임 입력 필드 구현
- 성별 버튼 구현
- 데이트 피커 구현

## 📌 참고 사항


## 📷 Screenshot
| 정보 등록 초기 화면 | 정보 등록 완료 |
| -- | -- |
| ![0](https://github.com/user-attachments/assets/cd27cb54-5663-4fb1-8d56-333db17464bd) | ![4](https://github.com/user-attachments/assets/63387155-30b9-4280-8c93-2f6a7661a2d6) |

| 프로필 사진 등록 | 입력 필드 활성화 | 정보 등록하기 버튼 활성화 |
| -- | -- | -- |
| ![1](https://github.com/user-attachments/assets/7724f825-6b89-41f5-a04a-503bb241fe4e) | ![2](https://github.com/user-attachments/assets/17985368-5c80-49f5-85a6-de6f2653bdae) | ![3](https://github.com/user-attachments/assets/9afe6212-9439-4b92-9fc4-c66ce268722b) |

### 실행 화면
![Simulator Screen Recording - iPhone 15 Pro - 2024-08-22 at 07 04 16](https://github.com/user-attachments/assets/7192965a-6cf4-4fb8-a242-218ecba6399f)

## 📮 관련 이슈
- Resolved: #94 
