### PR TITLE
[feat] 유저 정보 수정 api 연결

### DIFF
--- a/BookTalk/BookTalk.xcodeproj/project.pbxproj
+++ b/BookTalk/BookTalk.xcodeproj/project.pbxproj
@@ -128,6 +128,9 @@
 		AB5D35522C7759F00028995C /* EditUserInfoResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5D35512C7759F00028995C /* EditUserInfoResponseDTO.swift */; };
 		AB5D35552C775AB20028995C /* UserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5D35542C775AB20028995C /* UserInfo.swift */; };
 		AB5D35582C775ADE0028995C /* GenderType.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5D35572C775ADE0028995C /* GenderType.swift */; };
+		AB5D355B2C775DF70028995C /* UserTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5D355A2C775DF70028995C /* UserTarget.swift */; };
+		AB5D355D2C775DFF0028995C /* UserService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5D355C2C775DFF0028995C /* UserService.swift */; };
+		AB5D355F2C7767A00028995C /* DateFormatter+.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5D355E2C7767A00028995C /* DateFormatter+.swift */; };
 		AB8205552C6E661B0014C5A5 /* GenreTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB8205542C6E661B0014C5A5 /* GenreTarget.swift */; };
 		AB8205572C6E66240014C5A5 /* GenreService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB8205562C6E66240014C5A5 /* GenreService.swift */; };
 		AB82055C2C6E66BD0014C5A5 /* GenreTrendRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB82055B2C6E66BD0014C5A5 /* GenreTrendRequestDTO.swift */; };
@@ -282,6 +285,9 @@
 		AB5D35512C7759F00028995C /* EditUserInfoResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditUserInfoResponseDTO.swift; sourceTree = "<group>"; };
 		AB5D35542C775AB20028995C /* UserInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfo.swift; sourceTree = "<group>"; };
 		AB5D35572C775ADE0028995C /* GenderType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenderType.swift; sourceTree = "<group>"; };
+		AB5D355A2C775DF70028995C /* UserTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserTarget.swift; sourceTree = "<group>"; };
+		AB5D355C2C775DFF0028995C /* UserService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserService.swift; sourceTree = "<group>"; };
+		AB5D355E2C7767A00028995C /* DateFormatter+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateFormatter+.swift"; sourceTree = "<group>"; };
 		AB8205542C6E661B0014C5A5 /* GenreTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenreTarget.swift; sourceTree = "<group>"; };
 		AB8205562C6E66240014C5A5 /* GenreService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenreService.swift; sourceTree = "<group>"; };
 		AB82055B2C6E66BD0014C5A5 /* GenreTrendRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = GenreTrendRequestDTO.swift; path = BookTalk/Sources/DTO/Genre/Request/GenreTrendRequestDTO.swift; sourceTree = SOURCE_ROOT; };
@@ -789,6 +795,7 @@
 				AB949A322C7475720005C543 /* UserDefaults+.swift */,
 				AB949A342C7484F80005C543 /* UICollectionView+.swift */,
 				ABAAFDBC2C76FEFA00FDA084 /* UITableView+.swift */,
+				AB5D355E2C7767A00028995C /* DateFormatter+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -908,6 +915,7 @@
 			isa = PBXGroup;
 			children = (
 				AB4CBA5E2C6BB059009A2AB6 /* Foundation */,
+				AB5D35592C775DE70028995C /* User */,
 				AB8205532C6E66060014C5A5 /* Genre */,
 				ABB901AD2C727A2000727875 /* Book */,
 				ABB901C82C7398AC00727875 /* OpenTalk */,
@@ -1015,6 +1023,15 @@
 				AB5D35572C775ADE0028995C /* GenderType.swift */,
 			);
 			path = Enum;
+			sourceTree = "<group>";
+		};
+		AB5D35592C775DE70028995C /* User */ = {
+			isa = PBXGroup;
+			children = (
+				AB5D355A2C775DF70028995C /* UserTarget.swift */,
+				AB5D355C2C775DFF0028995C /* UserService.swift */,
+			);
+			path = User;
 			sourceTree = "<group>";
 		};
 		AB8205532C6E66060014C5A5 /* Genre */ = {
@@ -1366,6 +1383,7 @@
 				AB2E7BE52C53C97800CE43CB /* BookWithHeaderCell.swift in Sources */,
 				ABB901B12C727A3400727875 /* BookService.swift in Sources */,
 				AB2E7BEA2C53D69600CE43CB /* BookImageCell.swift in Sources */,
+				AB5D355F2C7767A00028995C /* DateFormatter+.swift in Sources */,
 				AB4CBA752C6E00FC009A2AB6 /* SettingViewController.swift in Sources */,
 				AB4CBA842C6E3320009A2AB6 /* BaseResponse.swift in Sources */,
 				AB8205572C6E66240014C5A5 /* GenreService.swift in Sources */,
@@ -1390,6 +1408,7 @@
 				AB0C0F7C2C5F6D45007812C5 /* MyReadingProgressCell.swift in Sources */,
 				AB8205622C6E687D0014C5A5 /* Encodable+.swift in Sources */,
 				ABAAFDBD2C76FEFA00FDA084 /* UITableView+.swift in Sources */,
+				AB5D355B2C775DF70028995C /* UserTarget.swift in Sources */,
 				AB5D35502C7759E60028995C /* EditUserInfoRequestDTO.swift in Sources */,
 				AB22AD3C2C4E8D9D00C9A0F3 /* AppDelegate.swift in Sources */,
 				AB2E7BE72C53D2A300CE43CB /* ShowAllBookCell.swift in Sources */,
@@ -1439,6 +1458,7 @@
 				ABAAFDB22C76FDAD00FDA084 /* SearchRequestDTO.swift in Sources */,
 				AB0C0F592C5BD98B007812C5 /* OpenTalkPageCell.swift in Sources */,
 				054FA17B2C7464E30007D9C9 /* SegmentedProgressBar.swift in Sources */,
+				AB5D355D2C775DFF0028995C /* UserService.swift in Sources */,
 				AB4CBA6C2C6DD8E7009A2AB6 /* NetworkService.swift in Sources */,
 				054543A22C5751DD00E64948 /* SuggestionCell.swift in Sources */,
 				AB8205552C6E661B0014C5A5 /* GenreTarget.swift in Sources */,

--- a/BookTalk/BookTalk.xcodeproj/project.pbxproj
+++ b/BookTalk/BookTalk.xcodeproj/project.pbxproj
@@ -124,6 +124,10 @@
 		AB4CBA812C6E09CD009A2AB6 /* SettingType.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB4CBA802C6E09CD009A2AB6 /* SettingType.swift */; };
 		AB4CBA842C6E3320009A2AB6 /* BaseResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB4CBA832C6E3320009A2AB6 /* BaseResponse.swift */; };
 		AB4ECF462C70848C00DC24A0 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = AB4ECF452C70848C00DC24A0 /* Kingfisher */; };
+		AB5D35502C7759E60028995C /* EditUserInfoRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5D354F2C7759E60028995C /* EditUserInfoRequestDTO.swift */; };
+		AB5D35522C7759F00028995C /* EditUserInfoResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5D35512C7759F00028995C /* EditUserInfoResponseDTO.swift */; };
+		AB5D35552C775AB20028995C /* UserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5D35542C775AB20028995C /* UserInfo.swift */; };
+		AB5D35582C775ADE0028995C /* GenderType.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5D35572C775ADE0028995C /* GenderType.swift */; };
 		AB8205552C6E661B0014C5A5 /* GenreTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB8205542C6E661B0014C5A5 /* GenreTarget.swift */; };
 		AB8205572C6E66240014C5A5 /* GenreService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB8205562C6E66240014C5A5 /* GenreService.swift */; };
 		AB82055C2C6E66BD0014C5A5 /* GenreTrendRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB82055B2C6E66BD0014C5A5 /* GenreTrendRequestDTO.swift */; };
@@ -274,6 +278,10 @@
 		AB4CBA7A2C6E0755009A2AB6 /* SettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewModel.swift; sourceTree = "<group>"; };
 		AB4CBA802C6E09CD009A2AB6 /* SettingType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingType.swift; sourceTree = "<group>"; };
 		AB4CBA832C6E3320009A2AB6 /* BaseResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseResponse.swift; sourceTree = "<group>"; };
+		AB5D354F2C7759E60028995C /* EditUserInfoRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditUserInfoRequestDTO.swift; sourceTree = "<group>"; };
+		AB5D35512C7759F00028995C /* EditUserInfoResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditUserInfoResponseDTO.swift; sourceTree = "<group>"; };
+		AB5D35542C775AB20028995C /* UserInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfo.swift; sourceTree = "<group>"; };
+		AB5D35572C775ADE0028995C /* GenderType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenderType.swift; sourceTree = "<group>"; };
 		AB8205542C6E661B0014C5A5 /* GenreTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenreTarget.swift; sourceTree = "<group>"; };
 		AB8205562C6E66240014C5A5 /* GenreService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenreService.swift; sourceTree = "<group>"; };
 		AB82055B2C6E66BD0014C5A5 /* GenreTrendRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = GenreTrendRequestDTO.swift; path = BookTalk/Sources/DTO/Genre/Request/GenreTrendRequestDTO.swift; sourceTree = SOURCE_ROOT; };
@@ -820,6 +828,8 @@
 		AB2E7BEB2C53DAFE00CE43CB /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				AB5D35562C775ACB0028995C /* Enum */,
+				AB5D35532C775AA30028995C /* User */,
 				054544132C5AA7F100E64948 /* BookInfo */,
 				0545438C2C5747E300E64948 /* Home */,
 				054543EE2C5A22F100E64948 /* Search */,
@@ -966,6 +976,47 @@
 			path = Enum;
 			sourceTree = "<group>";
 		};
+		AB5D354C2C7759790028995C /* User */ = {
+			isa = PBXGroup;
+			children = (
+				AB5D354D2C77599D0028995C /* Request */,
+				AB5D354E2C7759A20028995C /* Response */,
+			);
+			path = User;
+			sourceTree = "<group>";
+		};
+		AB5D354D2C77599D0028995C /* Request */ = {
+			isa = PBXGroup;
+			children = (
+				AB5D354F2C7759E60028995C /* EditUserInfoRequestDTO.swift */,
+			);
+			path = Request;
+			sourceTree = "<group>";
+		};
+		AB5D354E2C7759A20028995C /* Response */ = {
+			isa = PBXGroup;
+			children = (
+				AB5D35512C7759F00028995C /* EditUserInfoResponseDTO.swift */,
+			);
+			path = Response;
+			sourceTree = "<group>";
+		};
+		AB5D35532C775AA30028995C /* User */ = {
+			isa = PBXGroup;
+			children = (
+				AB5D35542C775AB20028995C /* UserInfo.swift */,
+			);
+			path = User;
+			sourceTree = "<group>";
+		};
+		AB5D35562C775ACB0028995C /* Enum */ = {
+			isa = PBXGroup;
+			children = (
+				AB5D35572C775ADE0028995C /* GenderType.swift */,
+			);
+			path = Enum;
+			sourceTree = "<group>";
+		};
 		AB8205532C6E66060014C5A5 /* Genre */ = {
 			isa = PBXGroup;
 			children = (
@@ -978,6 +1029,7 @@
 		AB8205592C6E665B0014C5A5 /* DTO */ = {
 			isa = PBXGroup;
 			children = (
+				AB5D354C2C7759790028995C /* User */,
 				ABAAFDAC2C76FD4000FDA084 /* Search */,
 				AB82055A2C6E666D0014C5A5 /* Genre */,
 				ABB901A92C72799400727875 /* Book */,
@@ -1292,6 +1344,7 @@
 			files = (
 				AB949A332C7475720005C543 /* UserDefaults+.swift in Sources */,
 				AB3F15462C611DC100C77E13 /* Observable.swift in Sources */,
+				AB5D35582C775ADE0028995C /* GenderType.swift in Sources */,
 				054543352C5374D900E64948 /* SearchViewController.swift in Sources */,
 				ABB901AB2C7279AA00727875 /* KeywordResponseDTO.swift in Sources */,
 				AB4CBA542C6B3FCE009A2AB6 /* AddBookViewModel.swift in Sources */,
@@ -1337,6 +1390,7 @@
 				AB0C0F7C2C5F6D45007812C5 /* MyReadingProgressCell.swift in Sources */,
 				AB8205622C6E687D0014C5A5 /* Encodable+.swift in Sources */,
 				ABAAFDBD2C76FEFA00FDA084 /* UITableView+.swift in Sources */,
+				AB5D35502C7759E60028995C /* EditUserInfoRequestDTO.swift in Sources */,
 				AB22AD3C2C4E8D9D00C9A0F3 /* AppDelegate.swift in Sources */,
 				AB2E7BE72C53D2A300CE43CB /* ShowAllBookCell.swift in Sources */,
 				056F304E2C60D54500931302 /* BookDetailViewModel.swift in Sources */,
@@ -1375,6 +1429,7 @@
 				051156052C64C73F00230CFE /* BaseCollectionViewCell.swift in Sources */,
 				ABED44132C665DD90073398A /* GoalModel.swift in Sources */,
 				057925392C4FF34A00834EC6 /* MainTabBarController.swift in Sources */,
+				AB5D35552C775AB20028995C /* UserInfo.swift in Sources */,
 				AB0C0F6D2C5BFE5C007812C5 /* ChatViewModel.swift in Sources */,
 				054FA1752C74643C0007D9C9 /* OnboardingManager.swift in Sources */,
 				056F30502C60D57100931302 /* BookInfoCell.swift in Sources */,
@@ -1402,6 +1457,7 @@
 				AB2E7BCE2C53ADF700CE43CB /* BaseViewController.swift in Sources */,
 				05CB069E2C769A1700673947 /* RegistrationViewController.swift in Sources */,
 				0579253F2C4FF4D700834EC6 /* OpenTalkViewController.swift in Sources */,
+				AB5D35522C7759F00028995C /* EditUserInfoResponseDTO.swift in Sources */,
 				AB4CBA4D2C6B2E4B009A2AB6 /* ChatMenuViewModel.swift in Sources */,
 				054FA1982C748E9F0007D9C9 /* EditLibraryViewController.swift in Sources */,
 				057925432C4FF4E100834EC6 /* MyViewController.swift in Sources */,

--- a/BookTalk/BookTalk/Info.plist
+++ b/BookTalk/BookTalk/Info.plist
@@ -3,9 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>NSPhotoLibraryUsageDescription</key>
-	<string>앨범 접근 권한이 필요합니다.</string>
+	<string>프로필 사진 설정을 위해 앨범 접근 권한이 필요합니다.</string>
 	<key>NSCameraUsageDescription</key>
-	<string>카메라 접근 권한이 필요합니다.</string>
+	<string>프로필 사진 설정을 위해 카메라 접근 권한이 필요합니다.</string>
 	<key>KakaoNativeAppKey</key>
 	<string>d3ddedc9b13b7bf5d046bd16a67e1e5c</string>
 	<key>BASE_URL</key>

--- a/BookTalk/BookTalk/Sources/Application/AppFlowController.swift
+++ b/BookTalk/BookTalk/Sources/Application/AppFlowController.swift
@@ -43,7 +43,16 @@ final class AppFlowController {
 
     private func goToHome() {
         let mainTabVC = MainTabBarController()
-        rootViewController = mainTabVC
+
+        UIView.transition(
+            with: window,
+            duration: 0.5,
+            options: .transitionCrossDissolve, 
+            animations: {
+                self.rootViewController = mainTabVC
+            },
+            completion: nil
+        )
     }
 
     private func goToLogin() {

--- a/BookTalk/BookTalk/Sources/Application/AppFlowController.swift
+++ b/BookTalk/BookTalk/Sources/Application/AppFlowController.swift
@@ -9,6 +9,7 @@ import UIKit
 
 /// 자동 로그인 처리 모듈
 /// 로그인 상태에 따라 초기 화면(로그인, 메인탭)으로 전환
+@MainActor
 final class AppFlowController {
     static let shared = AppFlowController()
 
@@ -47,7 +48,7 @@ final class AppFlowController {
 
     private func goToLogin() {
         let loginVC = LoginViewController()
-        rootViewController = loginVC
+        rootViewController = UINavigationController(rootViewController: loginVC)
     }
 
     @objc private func checkLoginState() {

--- a/BookTalk/BookTalk/Sources/Application/SceneDelegate.swift
+++ b/BookTalk/BookTalk/Sources/Application/SceneDelegate.swift
@@ -20,16 +20,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     ) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
 
-        // TODO: 변경
-        window = UIWindow(windowScene: windowScene)
-        window?.rootViewController = UINavigationController(rootViewController: RegistrationViewController())
-        window?.backgroundColor = .white
-        window?.makeKeyAndVisible()
+        let window = UIWindow(windowScene: windowScene)
+        self.window = window
 
-//        let window = UIWindow(windowScene: windowScene)
-//        self.window = window
-//
-//        AppFlowController.shared.show(in: window)
+        AppFlowController.shared.show(in: window)
     }
 
     func scene(

--- a/BookTalk/BookTalk/Sources/Application/SceneDelegate.swift
+++ b/BookTalk/BookTalk/Sources/Application/SceneDelegate.swift
@@ -20,10 +20,16 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     ) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
 
-        let window = UIWindow(windowScene: windowScene)
-        self.window = window
+        // TODO: 변경
+        window = UIWindow(windowScene: windowScene)
+        window?.rootViewController = UINavigationController(rootViewController: RegistrationViewController())
+        window?.backgroundColor = .white
+        window?.makeKeyAndVisible()
 
-        AppFlowController.shared.show(in: window)
+//        let window = UIWindow(windowScene: windowScene)
+//        self.window = window
+//
+//        AppFlowController.shared.show(in: window)
     }
 
     func scene(

--- a/BookTalk/BookTalk/Sources/DTO/User/Request/EditUserInfoRequestDTO.swift
+++ b/BookTalk/BookTalk/Sources/DTO/User/Request/EditUserInfoRequestDTO.swift
@@ -1,0 +1,14 @@
+//
+//  EditUserInfoRequestDTO.swift
+//  BookTalk
+//
+//  Created by 김민 on 8/22/24.
+//
+
+import Foundation
+
+struct EditUserInfoRequestDTO: Encodable {
+    let nickname: String
+    let gender: String
+    let birthDate: String
+}

--- a/BookTalk/BookTalk/Sources/DTO/User/Response/EditUserInfoResponseDTO.swift
+++ b/BookTalk/BookTalk/Sources/DTO/User/Response/EditUserInfoResponseDTO.swift
@@ -1,0 +1,14 @@
+//
+//  EditUserInfoResponseDTO.swift
+//  BookTalk
+//
+//  Created by 김민 on 8/22/24.
+//
+
+import Foundation
+
+struct EditUserInfoResponseDTO: Decodable {
+    let nickname: String
+    let gender: String
+    let birthDate: String
+}

--- a/BookTalk/BookTalk/Sources/Model/Enum/GenderType.swift
+++ b/BookTalk/BookTalk/Sources/Model/Enum/GenderType.swift
@@ -8,7 +8,18 @@
 import Foundation
 
 enum GenderType: String {
-    case notSelcted = "G0"
-    case man = "G1"
-    case woman = "G2"
+    case notSelcted = "NOT_SELECTED"
+    case man = "MAN"
+    case woman = "WOMAN"
+
+    var code: String {
+        switch self {
+        case .notSelcted:
+            return "G0"
+        case .man:
+            return "G1"
+        case .woman:
+            return "G2"
+        }
+    }
 }

--- a/BookTalk/BookTalk/Sources/Model/Enum/GenderType.swift
+++ b/BookTalk/BookTalk/Sources/Model/Enum/GenderType.swift
@@ -1,0 +1,14 @@
+//
+//  GenderType.swift
+//  BookTalk
+//
+//  Created by 김민 on 8/22/24.
+//
+
+import Foundation
+
+enum GenderType: String {
+    case notSelcted = "G0"
+    case man = "G1"
+    case woman = "G2"
+}

--- a/BookTalk/BookTalk/Sources/Model/User/UserInfo.swift
+++ b/BookTalk/BookTalk/Sources/Model/User/UserInfo.swift
@@ -1,0 +1,14 @@
+//
+//  UserInfo.swift
+//  BookTalk
+//
+//  Created by 김민 on 8/22/24.
+//
+
+import Foundation
+
+struct UserInfo {
+    let nickname: String
+    let gender: GenderType
+    let birth: String // TODO: 나이 계산
+}

--- a/BookTalk/BookTalk/Sources/Network/User/UserService.swift
+++ b/BookTalk/BookTalk/Sources/Network/User/UserService.swift
@@ -1,0 +1,27 @@
+//
+//  UserService.swift
+//  BookTalk
+//
+//  Created by 김민 on 8/22/24.
+//
+
+import Foundation
+
+struct UserService {
+
+    static func editUserInfo(
+        nickname: String,
+        gender: GenderType,
+        birthDate: String
+    ) async throws -> EditUserInfoResponseDTO {
+        let body: EditUserInfoRequestDTO = .init(
+            nickname: nickname,
+            gender: gender.rawValue,
+            birthDate: birthDate
+        )
+
+        let result: EditUserInfoResponseDTO = try await NetworkService.shared.request(target: UserTarget.editUserInfo(body: body))
+
+        return result
+    }
+}

--- a/BookTalk/BookTalk/Sources/Network/User/UserTarget.swift
+++ b/BookTalk/BookTalk/Sources/Network/User/UserTarget.swift
@@ -1,0 +1,38 @@
+//
+//  UserTarget.swift
+//  BookTalk
+//
+//  Created by 김민 on 8/22/24.
+//
+
+import Foundation
+
+import Alamofire
+
+enum UserTarget {
+    case editUserInfo(body: EditUserInfoRequestDTO)
+}
+
+extension UserTarget: TargetType {
+
+    var path: String {
+        switch self {
+        case .editUserInfo:
+            return "/api/user/info/edit"
+        }
+    }
+    
+    var method: HTTPMethod {
+        switch self {
+        case .editUserInfo:
+            return .put
+        }
+    }
+    
+    var task: APITask {
+        switch self {
+        case let .editUserInfo(body):
+            return .requestJSONEncodable(body: body)
+        }
+    }
+}

--- a/BookTalk/BookTalk/Sources/Presentation/Login/View/LoginViewController.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Login/View/LoginViewController.swift
@@ -85,10 +85,22 @@ final class LoginViewController: BaseViewController {
                 self?.progressView.updateProgress(segmentIndex: index, progress: progress)
             }
         }
+
+        viewModel.output.pushToRegister.subscribe { [weak self] isLoginCompleted in
+            guard let self = self else { return }
+            guard isLoginCompleted else { return }
+
+            let registerVC = RegistrationViewController()
+            navigationController?.pushViewController(registerVC, animated: true)
+        }
     }
     
     // MARK: - Set UI
-    
+
+    override func setNavigationBar() {
+        navigationController?.setNavigationBarHidden(true, animated: false)
+    }
+
     override func setViews() {
         configureWaveView()
         configureAnimationView()

--- a/BookTalk/BookTalk/Sources/Presentation/Login/ViewModel/LoginViewModel.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Login/ViewModel/LoginViewModel.swift
@@ -18,9 +18,12 @@ final class LoginViewModel {
     struct Output {
         let onboardingMessage: Observable<String>
         let progressUpdate: Observable<(Int, Float)>
+        let pushToRegister: Observable<Bool>
     }
     
     // MARK: - Properties
+
+    private var pushToRegisterOB = Observable(false)
 
     private let oauthManager = OAuthManager()
 
@@ -59,7 +62,8 @@ final class LoginViewModel {
     private func transform() -> Output {
         return Output(
             onboardingMessage: Observable(""),
-            progressUpdate: Observable((0, 1.0))
+            progressUpdate: Observable((0, 1.0)),
+            pushToRegister: pushToRegisterOB
         )
     }
     
@@ -75,6 +79,7 @@ final class LoginViewModel {
     private func handleLogin(type: LoginType) {
         switch type {
         case .apple:
+            // TODO: 애플 로그인
             oauthManager.loginWithApple()
 
             oauthManager.appleLoginSucceed = { credential in
@@ -83,7 +88,11 @@ final class LoginViewModel {
             }
 
         case .kakao:
-            oauthManager.loginWithKakao()
+            // FIXME: 임시로 입력폼으로 넘어가도록 구현 -> 추후 분기 처리하기
+            pushToRegisterOB.value.toggle()
+            return
+            // TODO: 카카오 로그인
+//            oauthManager.loginWithKakao()
         }
     }
     

--- a/BookTalk/BookTalk/Sources/Presentation/Registration/View/RegistrationViewController.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Registration/View/RegistrationViewController.swift
@@ -154,7 +154,6 @@ final class RegistrationViewController: BaseViewController {
         viewModel.nickname.subscribe { [weak self] nickname in
             self?.nicknameTextField.text = nickname
         }
-        
 
         viewModel.selectedGender.subscribe { [weak self] gender in
             self?.updateGenderSelection(gender)
@@ -166,6 +165,29 @@ final class RegistrationViewController: BaseViewController {
         
         viewModel.isFormValid.subscribe { [weak self] isValid in
             self?.updateSignUpButtonState(isValid: isValid)
+        }
+
+        viewModel.pushToHomeView.subscribe { [weak self] isCompleted in
+            guard let self = self else { return }
+
+            if isCompleted {
+                let mainTabVC = MainTabBarController()
+
+                if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                   let window = windowScene.windows.first {
+
+                    window.rootViewController = mainTabVC
+                    window.makeKeyAndVisible()
+
+                    UIView.transition(
+                        with: window,
+                        duration: 0.5,
+                        options: .transitionCrossDissolve,
+                        animations: nil,
+                        completion: nil
+                    )
+                }
+            }
         }
     }
     

--- a/BookTalk/BookTalk/Sources/Presentation/Registration/View/RegistrationViewController.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Registration/View/RegistrationViewController.swift
@@ -286,6 +286,7 @@ final class RegistrationViewController: BaseViewController {
             $0.datePickerMode = .date
             $0.preferredDatePickerStyle = .wheels
             $0.locale = .init(identifier: "ko-KR")
+            $0.maximumDate = Date()
         }
         
         signUpButton.do {

--- a/BookTalk/BookTalk/Sources/Presentation/Registration/View/RegistrationViewController.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Registration/View/RegistrationViewController.swift
@@ -23,7 +23,7 @@ final class RegistrationViewController: BaseViewController {
     private let datePicker = UIDatePicker()
     private let signUpButton = UIButton(type: .system)
     private let credentialsStackView = UIStackView()
-    
+
     // MARK: - Lifecycle
     
     override func viewDidLoad() {
@@ -54,21 +54,31 @@ final class RegistrationViewController: BaseViewController {
     }
     
     @objc private func selectMaleGender() {
-        viewModel.updateGender(.male)
+        viewModel.updateGender(.man)
     }
 
     @objc private func selectFemaleGender() {
-        viewModel.updateGender(.female)
+        viewModel.updateGender(.woman)
     }
     
     @objc private func dateChanged(_ sender: UIDatePicker) {
         viewModel.updateBirthDate(sender.date)
     }
     
-    @objc func doneButtonHandler() {
+    @objc private func doneButtonHandler() {
         birthTextField.attributedText = dateFormat(date: datePicker.date)
         viewModel.updateBirthDate(datePicker.date)
         birthTextField.resignFirstResponder()
+    }
+
+    @objc private func registerButtonDidTapped() {
+        viewModel.registerUserInfo(
+            nickname: viewModel.nickname.value,
+            gender: viewModel.selectedGender.value ?? .man,
+            birth: DateFormatter.koreanDateFormat.string(
+                from: viewModel.birthDate.value ?? Date()
+            )
+        )
     }
 
     @objc private func keyboardWillShow(_ notification: Notification) {
@@ -119,8 +129,7 @@ final class RegistrationViewController: BaseViewController {
         )
         maleButton.addTarget(
             self,
-            action: #selector(selectMaleGender
-                             ),
+            action: #selector(selectMaleGender),
             for: .touchUpInside)
         femaleButton.addTarget(
             self,
@@ -131,6 +140,11 @@ final class RegistrationViewController: BaseViewController {
             self,
             action: #selector(dateChanged),
             for: .valueChanged
+        )
+        signUpButton.addTarget(
+            self,
+            action: #selector(registerButtonDidTapped),
+            for: .touchUpInside
         )
     }
     
@@ -157,11 +171,11 @@ final class RegistrationViewController: BaseViewController {
     
     // MARK: - Helpers
     
-    private func updateGenderSelection(_ gender: Gender?) {
-        maleButton.backgroundColor = gender == .male ?
+    private func updateGenderSelection(_ gender: GenderType?) {
+        maleButton.backgroundColor = gender == .man ?
             .accentOrange : .accentOrange.withAlphaComponent(0.2)
         femaleButton.backgroundColor = gender ==
-            .female ? .accentOrange : .accentOrange.withAlphaComponent(0.2)
+            .woman ? .accentOrange : .accentOrange.withAlphaComponent(0.2)
     }
     
     private func dateFormat(date: Date?) -> NSAttributedString {
@@ -184,7 +198,7 @@ final class RegistrationViewController: BaseViewController {
     private func updateSignUpButtonState(isValid: Bool) {
         UIView.animate(withDuration: 0.3) {
             self.signUpButton.isEnabled = isValid
-            self.signUpButton.backgroundColor = isValid ? 
+            self.signUpButton.backgroundColor = isValid ?
                 .accentOrange : .accentOrange.withAlphaComponent(0.2)
             self.signUpButton.setTitleColor(
                 isValid ? .white : .systemBackground.withAlphaComponent(0.7),
@@ -192,7 +206,7 @@ final class RegistrationViewController: BaseViewController {
             )
         }
     }
-    
+
     // MARK: - Set UI
     
     override func setNavigationBar() {
@@ -434,8 +448,8 @@ private extension RegistrationViewController {
     }
     
     func setToolBar() {
-        let toolBar = UIToolbar()
-        
+        let toolBar = UIToolbar(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+
         let flexibleSpace = UIBarButtonItem(
             barButtonSystemItem: .flexibleSpace,
             target: nil,

--- a/BookTalk/BookTalk/Sources/Presentation/Registration/View/RegistrationViewController.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Registration/View/RegistrationViewController.swift
@@ -72,22 +72,22 @@ final class RegistrationViewController: BaseViewController {
     }
 
     @objc private func keyboardWillShow(_ notification: Notification) {
-        if !isKeyboardAlreadyShown {
-            UIView.animate(withDuration: 0.3) {
-                self.view.backgroundColor = .black.withAlphaComponent(0.8)
-                self.addPhotoButton.alpha = 0.2
-                self.view.bringSubviewToFront(self.credentialsStackView)
-            }
-            isKeyboardAlreadyShown = true
-        }
+//        if !isKeyboardAlreadyShown {
+//            UIView.animate(withDuration: 0.3) {
+//                self.view.backgroundColor = .black.withAlphaComponent(0.2)
+//                self.addPhotoButton.alpha = 0.2
+//                self.view.bringSubviewToFront(self.credentialsStackView)
+//            }
+//            isKeyboardAlreadyShown = true
+//        }
     }
 
     @objc private func keyboardWillHide(_ notification: Notification) {
-        UIView.animate(withDuration: 0.3) {
-            self.view.backgroundColor = .white
-            self.addPhotoButton.alpha = 1
-        }
-        isKeyboardAlreadyShown = false
+//        UIView.animate(withDuration: 0.3) {
+//            self.view.backgroundColor = .white
+//            self.addPhotoButton.alpha = 1
+//        }
+//        isKeyboardAlreadyShown = false
     }
     
     private func registerKeyboardNotifications() {
@@ -107,20 +107,41 @@ final class RegistrationViewController: BaseViewController {
     }
     
     private func addTargets() {
-        addPhotoButton.addTarget(self, action: #selector(addPhotoButtonTapped), for: .touchUpInside)
-        nicknameTextField.addTarget(self, action: #selector(nicknameChanged), for: .editingChanged)
-        maleButton.addTarget(self, action: #selector(selectMaleGender), for: .touchUpInside)
-        femaleButton.addTarget(self, action: #selector(selectFemaleGender), for: .touchUpInside)
-        datePicker.addTarget(self, action: #selector(dateChanged), for: .valueChanged)
+        addPhotoButton.addTarget(
+            self,
+            action: #selector(addPhotoButtonTapped),
+            for: .touchUpInside
+        )
+        nicknameTextField.addTarget(
+            self,
+            action: #selector(nicknameChanged),
+            for: .editingChanged
+        )
+        maleButton.addTarget(
+            self,
+            action: #selector(selectMaleGender
+                             ),
+            for: .touchUpInside)
+        femaleButton.addTarget(
+            self,
+            action: #selector(selectFemaleGender),
+            for: .touchUpInside
+        )
+        datePicker.addTarget(
+            self,
+            action: #selector(dateChanged),
+            for: .valueChanged
+        )
     }
     
     // MARK: - Bind
     
     private func bind() {
-        viewModel.nickname.subscribe { [weak self] _ in
-            self?.nicknameTextField.text = self?.viewModel.nickname.value
+        viewModel.nickname.subscribe { [weak self] nickname in
+            self?.nicknameTextField.text = nickname
         }
         
+
         viewModel.selectedGender.subscribe { [weak self] gender in
             self?.updateGenderSelection(gender)
         }
@@ -179,19 +200,21 @@ final class RegistrationViewController: BaseViewController {
     }
     
     override func setViews() {
+        view.backgroundColor = .white
+        
         addPhotoButton.do {
             $0.setImage(
                 UIImage(systemName: "plus")?
-                    .withTintColor(.systemBlue, renderingMode: .alwaysOriginal)
+                    .withTintColor(.gray100, renderingMode: .alwaysOriginal)
                     .withConfiguration(
-                        UIImage.SymbolConfiguration(pointSize: 30, weight: .light)
+                        UIImage.SymbolConfiguration(pointSize: 20, weight: .light)
                     ),
                 for: .normal
             )
-            $0.layer.cornerRadius = 180 / 2
+            $0.layer.cornerRadius = 150 / 2
             $0.layer.masksToBounds = true
             $0.layer.borderWidth = 1
-            $0.layer.borderColor = UIColor.accentOrange.cgColor
+            $0.layer.borderColor = UIColor.gray100.cgColor
         }
         
         setupTextField(
@@ -243,7 +266,7 @@ final class RegistrationViewController: BaseViewController {
             $0.addArrangedSubview(birthTextField)
             $0.addArrangedSubview(signUpButton)
             $0.axis = .vertical
-            $0.spacing = 10
+            $0.spacing = 20
         }
     }
     
@@ -254,7 +277,7 @@ final class RegistrationViewController: BaseViewController {
         addPhotoButton.snp.makeConstraints {
             $0.centerX.equalToSuperview()
             $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(20)
-            $0.size.equalTo(180)
+            $0.size.equalTo(150)
         }
         
         nicknameTextField.snp.makeConstraints {
@@ -267,7 +290,7 @@ final class RegistrationViewController: BaseViewController {
         
         credentialsStackView.snp.makeConstraints {
             $0.centerX.equalTo(addPhotoButton)
-            $0.top.lessThanOrEqualTo(addPhotoButton.snp.bottom).offset(20)
+            $0.top.lessThanOrEqualTo(addPhotoButton.snp.bottom).offset(50)
             $0.left.equalTo(10)
             $0.bottom.equalTo(view.keyboardLayoutGuide.snp.top).offset(-20)
         }

--- a/BookTalk/BookTalk/Sources/Presentation/Registration/View/RegistrationViewController.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Registration/View/RegistrationViewController.swift
@@ -166,29 +166,6 @@ final class RegistrationViewController: BaseViewController {
         viewModel.isFormValid.subscribe { [weak self] isValid in
             self?.updateSignUpButtonState(isValid: isValid)
         }
-
-        viewModel.pushToHomeView.subscribe { [weak self] isCompleted in
-            guard let self = self else { return }
-
-            if isCompleted {
-                let mainTabVC = MainTabBarController()
-
-                if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-                   let window = windowScene.windows.first {
-
-                    window.rootViewController = mainTabVC
-                    window.makeKeyAndVisible()
-
-                    UIView.transition(
-                        with: window,
-                        duration: 0.5,
-                        options: .transitionCrossDissolve,
-                        animations: nil,
-                        completion: nil
-                    )
-                }
-            }
-        }
     }
     
     // MARK: - Helpers
@@ -232,6 +209,8 @@ final class RegistrationViewController: BaseViewController {
     // MARK: - Set UI
     
     override func setNavigationBar() {
+        navigationItem.hidesBackButton = true
+        navigationController?.setNavigationBarHidden(false, animated: false)
         navigationController?.navigationBar.topItem?.title = "정보 등록"
     }
     

--- a/BookTalk/BookTalk/Sources/Presentation/Registration/ViewModel/RegistrationViewModel.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Registration/ViewModel/RegistrationViewModel.swift
@@ -9,8 +9,6 @@ import UIKit
 
 struct RegistrationViewModel {
     
-    // MARK: - Inputs
-    
     let nickname = Observable<String>("")
     let selectedGender = Observable<GenderType?>(nil)
     let birthDate = Observable<Date?>(nil)
@@ -41,13 +39,19 @@ struct RegistrationViewModel {
     ) {
         Task {
             do {
-                let newUserInfo = try await UserService.editUserInfo(
+                _ = try await UserService.editUserInfo(
                     nickname: nickname,
                     gender: gender,
                     birthDate: birth
                 )
 
-                pushToHomeView.value.toggle()
+                await MainActor.run {
+                    UserDefaults.standard.set(true, forKey: UserDefaults.Key.isLoggedIn)
+                    NotificationCenter.default.post(
+                        name: Notification.Name.authStateChanged,
+                        object: nil
+                    )
+                }
             } catch let error as NetworkError {
                 print(error.localizedDescription)
             }

--- a/BookTalk/BookTalk/Sources/Presentation/Registration/ViewModel/RegistrationViewModel.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Registration/ViewModel/RegistrationViewModel.swift
@@ -15,7 +15,8 @@ struct RegistrationViewModel {
     let selectedGender = Observable<GenderType?>(nil)
     let birthDate = Observable<Date?>(nil)
     let isFormValid = Observable<Bool>(false)
-    
+    let pushToHomeView = Observable<Bool>(false)
+
     // MARK: - Actions
     
     func updateNickname(_ text: String) {
@@ -45,7 +46,8 @@ struct RegistrationViewModel {
                     gender: gender,
                     birthDate: birth
                 )
-                print(newUserInfo)
+
+                pushToHomeView.value.toggle()
             } catch let error as NetworkError {
                 print(error.localizedDescription)
             }

--- a/BookTalk/BookTalk/Sources/Presentation/Registration/ViewModel/RegistrationViewModel.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Registration/ViewModel/RegistrationViewModel.swift
@@ -7,16 +7,12 @@
 
 import UIKit
 
-enum Gender {
-    case male, female
-}
-
 struct RegistrationViewModel {
     
     // MARK: - Inputs
     
     let nickname = Observable<String>("")
-    let selectedGender = Observable<Gender?>(nil)
+    let selectedGender = Observable<GenderType?>(nil)
     let birthDate = Observable<Date?>(nil)
     let isFormValid = Observable<Bool>(false)
     
@@ -27,7 +23,7 @@ struct RegistrationViewModel {
         validateForm()
     }
     
-    func updateGender(_ gender: Gender) {
+    func updateGender(_ gender: GenderType) {
         selectedGender.value = gender
         validateForm()
     }
@@ -36,7 +32,26 @@ struct RegistrationViewModel {
         birthDate.value = date
         validateForm()
     }
-    
+
+    func registerUserInfo(
+        nickname: String,
+        gender: GenderType,
+        birth: String
+    ) {
+        Task {
+            do {
+                let newUserInfo = try await UserService.editUserInfo(
+                    nickname: nickname,
+                    gender: gender,
+                    birthDate: birth
+                )
+                print(newUserInfo)
+            } catch let error as NetworkError {
+                print(error.localizedDescription)
+            }
+        }
+    }
+
     // MARK: - Helpers
     
     private func validateForm() {

--- a/BookTalk/BookTalk/Sources/Util/Extension/DateFormatter+.swift
+++ b/BookTalk/BookTalk/Sources/Util/Extension/DateFormatter+.swift
@@ -1,0 +1,17 @@
+//
+//  DateFormatter+.swift
+//  BookTalk
+//
+//  Created by 김민 on 8/22/24.
+//
+
+import Foundation
+
+extension DateFormatter {
+
+    static let koreanDateFormat: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
+}


### PR DESCRIPTION
## 📚 PR 요약
유저 정보 수정 api 연결

## 📝 작업 내용
- 로그인 로직 화면 전환
- 약간의 레이아웃 수정 (간격 등)
- 오늘 이후의 날짜는 선택하지 못하도록 설정

## 📌 참고 사항
- 자동 로그인이 꺼졌을 때 카카오 로그인 버튼 탭 -> 정보 입력폼 -> 통신 성공 시 메인탭으로 이동하도록 임시로 구현되었습니다.
- 이미지 전송은 서버쪽에서 구현이 되면 같이 넣어서 통신 작업 하겠습니다.

## 📷 Screenshot
<img src = "https://github.com/user-attachments/assets/4c89396c-4817-4d98-8a31-9a76f4ab074c" width = 30%>


## 📮 관련 이슈
- Resolved: #104
