### PR TITLE
[style] 책 상세페이지 UI 수정

### DIFF
--- a/BookTalk/BookTalk/Sources/Presentation/BookDetail/Cell/TableViewCell/BookInfoCell.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/BookDetail/Cell/TableViewCell/BookInfoCell.swift
@@ -66,28 +66,33 @@ final class BookInfoCell: BaseTableViewCell {
         authorLabel.do {
             $0.textColor = .black
             $0.textAlignment = .left
+            $0.numberOfLines = 0
             $0.font = .systemFont(ofSize: 15, weight: .medium)
         }
         
         publisherLabel.do {
             $0.textColor = .black
             $0.textAlignment = .left
+            $0.numberOfLines = 0
             $0.font = .systemFont(ofSize: 15, weight: .medium)
         }
         
         publicationDateLabel.do {
             $0.textColor = .black
             $0.textAlignment = .left
+            $0.numberOfLines = 0
             $0.font = .systemFont(ofSize: 15, weight: .medium)
         }
         
         availabilityLabel.do {
             $0.textColor = .black
             $0.textAlignment = .left
+            $0.numberOfLines = 0
             $0.font = .systemFont(ofSize: 15, weight: .bold)
         }
         
         bookInfoStackView.do {
+            $0.addArrangedSubview(titleLabel)
             $0.addArrangedSubview(authorLabel)
             $0.addArrangedSubview(publisherLabel)
             $0.addArrangedSubview(publicationDateLabel)
@@ -138,29 +143,22 @@ final class BookInfoCell: BaseTableViewCell {
             $0.height.equalTo(250)
         }
         
-        titleLabel.snp.makeConstraints {
-            $0.centerX.equalToSuperview()
-            $0.top.equalTo(bookImageView.snp.bottom).offset(10)
-            $0.left.equalTo(bookImageView)
-        }
-        
         bookInfoStackView.snp.makeConstraints {
-            $0.centerX.left.equalTo(titleLabel)
-            $0.top.equalTo(titleLabel.snp.bottom).offset(10)
+            $0.centerX.left.equalTo(bookImageView)
+            $0.top.equalTo(bookImageView.snp.bottom).offset(10)
         }
         
         joinOpenTalkButton.snp.makeConstraints {
-            $0.centerX.equalToSuperview()
+            $0.centerX.left.equalTo(bookInfoStackView)
             $0.top.equalTo(bookInfoStackView.snp.bottom).offset(15)
-            $0.left.equalTo(bookInfoStackView)
             $0.height.equalTo(50)
         }
         
         markAsReadButton.snp.makeConstraints {
-            $0.centerX.equalToSuperview()
+            $0.centerX.left.equalTo(joinOpenTalkButton)
             $0.top.equalTo(joinOpenTalkButton.snp.bottom).offset(15)
-            $0.left.equalTo(joinOpenTalkButton)
-            $0.bottom.equalToSuperview().offset(-15)
+            $0.bottom.equalTo(-15)
+            $0.height.equalTo(30)
         }
     }
 }

--- a/BookTalk/BookTalk/Sources/Presentation/BookDetail/Cell/TableViewCell/BorrowableLibraryCell.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/BookDetail/Cell/TableViewCell/BorrowableLibraryCell.swift
@@ -7,24 +7,58 @@
 
 import UIKit
 
+protocol BorrowableLibraryCellDelegate: AnyObject {
+    func pushToMyLibraryVC()
+}
+
 final class BorrowableLibraryCell: BaseTableViewCell {
     
     // MARK: - Properties
     
+    weak var delegate: BorrowableLibraryCellDelegate?
+    
     private let titleLabel = UILabel()
     private let libraryStackView = UIStackView()
     private let registerLibraryButton = UIButton(type: .system)
+    
+    // MARK: - Initializer
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        
+        addTargets()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Actions
+    
+    @objc private func pushToMyLibraryVC() {
+        delegate?.pushToMyLibraryVC()
+    }
+    
+    private func addTargets() {
+        registerLibraryButton.addTarget(
+            self,
+            action: #selector(pushToMyLibraryVC),
+            for: .touchUpInside
+        )
+    }
     
     // MARK: - Bind
     
     func bind(_ viewModel: BookDetailViewModel) {
         viewModel.output.borrowableLibraries.subscribe { [weak self] libraries in
             guard let self = self else { return }
-
-            if let libraries = libraries {
+            
+            if let libraries = libraries, !libraries.isEmpty {
+                registerLibraryButton.isHidden = true
                 updateLibraries(libraries)
             } else {
-                registerLibraryButton.isHidden = true
+                registerLibraryButton.isHidden = false
+                libraryStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
             }
         }
     }
@@ -90,7 +124,6 @@ final class BorrowableLibraryCell: BaseTableViewCell {
             $0.setTitle("도서관 등록하기", for: .normal)
             $0.setTitleColor(.white, for: .normal)
             $0.titleLabel?.font = .systemFont(ofSize: 17, weight: .bold)
-            $0.isHidden = true
         }
     }
     

--- a/BookTalk/BookTalk/Sources/Presentation/BookDetail/Cell/TableViewCell/BorrowableLibraryCell.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/BookDetail/Cell/TableViewCell/BorrowableLibraryCell.swift
@@ -78,7 +78,7 @@ final class BorrowableLibraryCell: BaseTableViewCell {
         
         libraryStackView.do {
             $0.axis = .vertical
-            $0.alignment = .leading
+            $0.alignment = .fill
             $0.distribution = .fill
             $0.spacing = 5
         }
@@ -110,10 +110,9 @@ final class BorrowableLibraryCell: BaseTableViewCell {
         }
         
         registerLibraryButton.snp.makeConstraints {
-            $0.centerX.equalToSuperview()
+            $0.centerX.left.equalTo(libraryStackView)
             $0.top.equalTo(titleLabel.snp.bottom).offset(15)
-            $0.left.equalTo(15)
-            $0.bottom.equalToSuperview().inset(15)
+            $0.bottom.equalToSuperview()
             $0.height.equalTo(50)
         }
     }

--- a/BookTalk/BookTalk/Sources/Presentation/BookDetail/View/BookDetailViewController.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/BookDetail/View/BookDetailViewController.swift
@@ -45,6 +45,13 @@ final class BookDetailViewController: BaseViewController {
         viewModel.input.loadDetailInfo()
     }
     
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        
+        let bottomInset = view.bounds.height - floatingButton.frame.minY
+        tableView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: bottomInset, right: 0)
+    }
+    
     // MARK: - Actions
     
     @objc private func handleFavoriteButton() {
@@ -133,7 +140,12 @@ final class BookDetailViewController: BaseViewController {
     
     override func setViews() {
         view.backgroundColor = .white
-        tableView.separatorInset = .zero
+        
+        tableView.do {
+            $0.separatorInset = .zero
+            $0.estimatedRowHeight = 600
+            $0.rowHeight = UITableView.automaticDimension
+        }
         
         floatingButton.do {
             var config = UIButton.Configuration.filled()
@@ -164,12 +176,7 @@ final class BookDetailViewController: BaseViewController {
             $0.configuration?.baseBackgroundColor = .systemRed
             $0.setImage(UIImage(systemName: "hand.thumbsdown"), for: .normal)
         }
-
-        // TODO: 삭제
-        tableView.do {
-            $0.rowHeight = 600
-        }
-
+        
         indicatorView.do {
             $0.hidesWhenStopped = true
         }

--- a/BookTalk/BookTalk/Sources/Presentation/BookDetail/View/BookDetailViewController.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/BookDetail/View/BookDetailViewController.swift
@@ -325,6 +325,7 @@ extension BookDetailViewController: UITableViewDataSource {
             ) as? BorrowableLibraryCell else {
                 return UITableViewCell()
             }
+            cell.delegate = self
             cell.selectionStyle = .none
             cell.bind(viewModel)
             return cell
@@ -346,5 +347,15 @@ extension BookDetailViewController: UITableViewDelegate {
         } else {
             cell.separatorInset = UIEdgeInsets(top: 0, left: 15, bottom: 0, right: 15)
         }
+    }
+}
+
+// MARK: - BorrowableLibraryCellDelegate
+
+extension BookDetailViewController: BorrowableLibraryCellDelegate {
+    
+    func pushToMyLibraryVC() {
+        let myLibraryVC = MyLibraryViewController()
+        navigationController?.pushViewController(myLibraryVC, animated: true)
     }
 }

--- a/BookTalk/BookTalk/Sources/Presentation/BookDetail/ViewModel/BookDetailViewModel.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/BookDetail/ViewModel/BookDetailViewModel.swift
@@ -12,6 +12,7 @@ final class BookDetailViewModel {
     // MARK: - Interactions
     
     struct Input {
+        let markAsReadButtonTap: () -> Void
         let favoriteButtonTap: () -> Void
         let likeButtonTap: () -> Void
         let dislikeButtonTap: () -> Void
@@ -22,6 +23,7 @@ final class BookDetailViewModel {
         let detailBook: Observable<DetailBookInfo?>
         let availabilityText: Observable<String>
         let availabilityTextColor: Observable<UIColor>
+        let isMarkAsRead: Observable<Bool>
         let areChildButtonsVisible: Observable<Bool>
         let isFavorite: Observable<Bool>
         let isLiked: Observable<Bool>
@@ -37,6 +39,7 @@ final class BookDetailViewModel {
 
     private var availabilityText = Observable("")
     private var availabilityColor = Observable(UIColor.black)
+    private var isMarkAsReadOb = Observable(false)
     private var isFavoriteOb = Observable(false)
     private var loadStateOb = Observable(LoadState.initial)
 
@@ -55,6 +58,9 @@ final class BookDetailViewModel {
     
     private func bindInput() -> Input {
         return Input(
+            markAsReadButtonTap: { [weak self] in
+                self?.toggle(self?.output.isMarkAsRead)
+            },
             favoriteButtonTap: { [weak self] in
                 self?.toggle(self?.output.isFavorite)
             },
@@ -98,7 +104,8 @@ final class BookDetailViewModel {
         return Output(
             detailBook: bookDetailOb,
             availabilityText: availabilityText,
-            availabilityTextColor: availabilityColor,
+            availabilityTextColor: availabilityColor, 
+            isMarkAsRead: isMarkAsReadOb,
             areChildButtonsVisible: Observable(false),
             isFavorite: isFavoriteOb,
             isLiked: Observable(false),

--- a/BookTalk/BookTalk/Sources/Presentation/BookDetail/ViewModel/BookDetailViewModel.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/BookDetail/ViewModel/BookDetailViewModel.swift
@@ -80,7 +80,6 @@ final class BookDetailViewModel {
 
                             bookDetailOb.value = bookDetail
                             availableLibs.value = bookDetail.registeredLibraries
-                            (availabilityText.value, availabilityColor.value) = updateAvailability(availableLibs.value)
                             isFavoriteOb.value = bookDetail.isFavorite
 
                             loadStateOb.value = .completed
@@ -121,17 +120,18 @@ extension BookDetailViewModel {
         if let opposite = opposite, property.value { opposite.value = false }
     }
 
-    private func updateAvailability(
+    func updateAvailability(
         _ libraries: [Library]?
     ) -> (text: String, color: UIColor) {
-        guard let libraries = libraries else {
+        guard let libraries = libraries, !libraries.isEmpty else {
             return ("대출 여부를 확인하려면 도서관을 등록해주세요.", .systemGray)
         }
 
         let isAvailable = libraries.contains { $0.isAvailable }
-        let text = isAvailable ? "대출 가능" : "대출 불가능"
-        let color = isAvailable ? UIColor.systemGreen : .systemRed
-
-        return (text, color)
+        
+        return (
+            isAvailable ? "대출 가능" : "대출 불가능",
+            isAvailable ? .systemGreen : .systemRed
+        )
     }
 }


### PR DESCRIPTION
## 📚 PR 요약
책 상세페이지 UI 수정

## 📝 작업 내용
- 텍스트 길이 길어졌을 때 레이아웃 깨짐 현상 해결
- 도서관 등록하기 버튼 연결
- 읽은 책으로 추가하기 버튼 토글로 변경

## 📌 참고 사항


## 📷 Screenshot
| 읽은 책으로 추가 전 | 읽은 책으로 추가 후 |
| -- | -- |
| ![0](https://github.com/user-attachments/assets/1fea0f63-c5d8-47e9-aacc-3a53e191fdd2) | ![1](https://github.com/user-attachments/assets/4fee33b4-518f-40a6-a038-b70188f0eedb) |

| 등록한 도서관 없는 경우 | 도서관 등록하기 버튼 클릭 시 |
| -- | -- |
| ![2](https://github.com/user-attachments/assets/ad0eec55-75bc-422e-8ff6-20417411238f) | ![3](https://github.com/user-attachments/assets/1bcb4a55-1ba3-477f-929e-ada0f0a470dc) |

## 📮 관련 이슈
- Resolved: #97 
