### PR TITLE
[feat] apple login api 구현

### DIFF
--- a/BookTalk/BookTalk/Sources/Network/Auth/AuthService.swift
+++ b/BookTalk/BookTalk/Sources/Network/Auth/AuthService.swift
@@ -21,4 +21,16 @@ struct AuthService {
 
         return result.isNewUser
     }
-}
+
+    static func loginWithApple(idToken: String) async throws -> Bool {
+        let params: LoginRequestDTO = .init(idToken: idToken)
+
+        let result: LoginResponseDTO = try await NetworkService.shared.request(
+            target: AuthTarget.loginWithApple(params: params)
+        )
+
+        KeychainManager.shared.save(key: TokenKey.accessToken, token: result.accessToken)
+        KeychainManager.shared.save(key: TokenKey.refreshToken, token: result.refreshToken)
+
+        return result.isNewUser
+    }}

--- a/BookTalk/BookTalk/Sources/Network/Auth/AuthTarget.swift
+++ b/BookTalk/BookTalk/Sources/Network/Auth/AuthTarget.swift
@@ -11,6 +11,7 @@ import Alamofire
 
 enum AuthTarget {
     case loginWithKakao(params: LoginRequestDTO)
+    case loginWithApple(params: LoginRequestDTO)
 }
 
 extension AuthTarget: TargetType {
@@ -19,19 +20,22 @@ extension AuthTarget: TargetType {
         switch self {
         case .loginWithKakao:
             return "/api/auth/kakaoLogin"
+        case .loginWithApple:
+            return "/api/auth/appleLogin"
         }
     }
-    
+
     var method: HTTPMethod {
         switch self {
-        case .loginWithKakao:
+        case .loginWithKakao, .loginWithApple:
             return .post
         }
     }
-    
+
     var task: APITask {
         switch self {
-        case let .loginWithKakao(params):
+        case let .loginWithKakao(params),
+            let .loginWithApple(params):
             return .requestWithoutInterceptor(parameters: ["idToken": params.idToken])
         }
     }

--- a/BookTalk/BookTalk/Sources/Presentation/Login/Manager/OAuthManager.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Login/Manager/OAuthManager.swift
@@ -13,7 +13,6 @@ import KakaoSDKUser
 final class OAuthManager: NSObject {
 
     var appleLoginSucceed: ((ASAuthorizationAppleIDCredential) -> Void)?
-    var kakaoLoginSucceed: ((String) -> Void)?
 
     func loginWithKakao(completion: @escaping (Result<String, Error>) -> Void) {
         if UserApi.isKakaoTalkLoginAvailable() {
@@ -39,13 +38,18 @@ final class OAuthManager: NSObject {
         }
     }
 
-    func loginWithApple() {
+    func loginWithApple(completion: @escaping (Result<ASAuthorizationAppleIDCredential, Error>) -> Void) {
         let request = ASAuthorizationAppleIDProvider().createRequest()
         request.requestedScopes = [.fullName, .email]
 
         let authorizationController = ASAuthorizationController(authorizationRequests: [request])
         authorizationController.delegate = self
         authorizationController.presentationContextProvider = self
+
+        self.appleLoginSucceed = { credential in
+            completion(.success(credential))
+        }
+
         authorizationController.performRequests()
     }
 }


### PR DESCRIPTION
## 📚 PR 요약
 apple login api 구현

## 📝 작업 내용
- 애플 로그인 api 연결
- 카카오 로그인 로직과 동일하게 작업했습니다!

## 📌 참고 사항
- 애플 로그인도 테스트 부탁드리겠습니다!

## 📷 Screenshot
<img src = "https://github.com/user-attachments/assets/0b2240d4-7fe8-42d1-99c2-36787a539c71" width = 50%>

## 📮 관련 이슈
- Resolved: #118 
