### PR TITLE
[feat] 유저 정보 조회 api 연결 및 저장

### DIFF
--- a/BookTalk/BookTalk.xcodeproj/project.pbxproj
+++ b/BookTalk/BookTalk.xcodeproj/project.pbxproj
@@ -59,8 +59,8 @@
 		0579D1182C6C9FC30032AC1C /* KeywordViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0579D1172C6C9FC30032AC1C /* KeywordViewModel.swift */; };
 		058B77B72C78581000A1110B /* FinishedBook.swift in Sources */ = {isa = PBXBuildFile; fileRef = 058B77B62C78581000A1110B /* FinishedBook.swift */; };
 		058B77BC2C7858FF00A1110B /* FavoriteBook.swift in Sources */ = {isa = PBXBuildFile; fileRef = 058B77BB2C7858FF00A1110B /* FavoriteBook.swift */; };
-		05CB069C2C7699E100673947 /* RegistrationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05CB069B2C7699E100673947 /* RegistrationViewModel.swift */; };
-		05CB069E2C769A1700673947 /* RegistrationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05CB069D2C769A1700673947 /* RegistrationViewController.swift */; };
+		05CB069C2C7699E100673947 /* UserInfoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05CB069B2C7699E100673947 /* UserInfoViewModel.swift */; };
+		05CB069E2C769A1700673947 /* UserInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05CB069D2C769A1700673947 /* UserInfoViewController.swift */; };
 		AB0784812C74F8910017812F /* KakaoSDKAuth in Frameworks */ = {isa = PBXBuildFile; productRef = AB0784802C74F8910017812F /* KakaoSDKAuth */; };
 		AB0784832C74F8910017812F /* KakaoSDKUser in Frameworks */ = {isa = PBXBuildFile; productRef = AB0784822C74F8910017812F /* KakaoSDKUser */; };
 		AB0784852C74FA1D0017812F /* OAuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0784842C74FA1D0017812F /* OAuthManager.swift */; };
@@ -245,8 +245,8 @@
 		0579D1172C6C9FC30032AC1C /* KeywordViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeywordViewModel.swift; sourceTree = "<group>"; };
 		058B77B62C78581000A1110B /* FinishedBook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinishedBook.swift; sourceTree = "<group>"; };
 		058B77BB2C7858FF00A1110B /* FavoriteBook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteBook.swift; sourceTree = "<group>"; };
-		05CB069B2C7699E100673947 /* RegistrationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationViewModel.swift; sourceTree = "<group>"; };
-		05CB069D2C769A1700673947 /* RegistrationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationViewController.swift; sourceTree = "<group>"; };
+		05CB069B2C7699E100673947 /* UserInfoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoViewModel.swift; sourceTree = "<group>"; };
+		05CB069D2C769A1700673947 /* UserInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoViewController.swift; sourceTree = "<group>"; };
 		AB0784842C74FA1D0017812F /* OAuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthManager.swift; sourceTree = "<group>"; };
 		AB0784862C74FF2C0017812F /* BookTalk.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = BookTalk.entitlements; sourceTree = "<group>"; };
 		AB07848A2C75A89E0017812F /* ISBNRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ISBNRequestDTO.swift; sourceTree = "<group>"; };
@@ -662,7 +662,7 @@
 			isa = PBXGroup;
 			children = (
 				054FA16F2C7464120007D9C9 /* Login */,
-				05CB06982C7699CD00673947 /* Registration */,
+				05CB06982C7699CD00673947 /* UserInfo */,
 				056F2FEE2C5B4E3600931302 /* MainTab */,
 				056F30472C60D4E400931302 /* BookDetail */,
 				0545432E2C53725200E64948 /* Home */,
@@ -695,19 +695,19 @@
 			path = MyPage;
 			sourceTree = "<group>";
 		};
-		05CB06982C7699CD00673947 /* Registration */ = {
+		05CB06982C7699CD00673947 /* UserInfo */ = {
 			isa = PBXGroup;
 			children = (
 				05CB069A2C7699D900673947 /* View */,
 				05CB06992C7699D400673947 /* ViewModel */,
 			);
-			path = Registration;
+			path = UserInfo;
 			sourceTree = "<group>";
 		};
 		05CB06992C7699D400673947 /* ViewModel */ = {
 			isa = PBXGroup;
 			children = (
-				05CB069B2C7699E100673947 /* RegistrationViewModel.swift */,
+				05CB069B2C7699E100673947 /* UserInfoViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -715,7 +715,7 @@
 		05CB069A2C7699D900673947 /* View */ = {
 			isa = PBXGroup;
 			children = (
-				05CB069D2C769A1700673947 /* RegistrationViewController.swift */,
+				05CB069D2C769A1700673947 /* UserInfoViewController.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1717,7 +1717,7 @@
 				054543F22C5A233600E64948 /* SearchMockData.swift in Sources */,
 				051155F12C64B08F00230CFE /* ReusableIdentifier.swift in Sources */,
 				AB2E7BCE2C53ADF700CE43CB /* BaseViewController.swift in Sources */,
-				05CB069E2C769A1700673947 /* RegistrationViewController.swift in Sources */,
+				05CB069E2C769A1700673947 /* UserInfoViewController.swift in Sources */,
 				0579253F2C4FF4D700834EC6 /* OpenTalkViewController.swift in Sources */,
 				AB5D35522C7759F00028995C /* EditUserInfoResponseDTO.swift in Sources */,
 				AB4CBA4D2C6B2E4B009A2AB6 /* ChatMenuViewModel.swift in Sources */,
@@ -1737,7 +1737,7 @@
 				AB2E7BFE2C5602A500CE43CB /* Category.swift in Sources */,
 				AB4CBA782C6E037B009A2AB6 /* SettingCell.swift in Sources */,
 				AB8224AC2C7843440082CD30 /* SearchLibraryViewController.swift in Sources */,
-				05CB069C2C7699E100673947 /* RegistrationViewModel.swift in Sources */,
+				05CB069C2C7699E100673947 /* UserInfoViewModel.swift in Sources */,
 				ABB901C42C73980600727875 /* OpenTalkResponseDTO.swift in Sources */,
 				AB9C5D672C78AEFC00CE44AF /* EditLibraryRequestDTO.swift in Sources */,
 				AB6C19CD2C79A0ED00BF844C /* BookRequestDTO.swift in Sources */,

--- a/BookTalk/BookTalk.xcodeproj/project.pbxproj
+++ b/BookTalk/BookTalk.xcodeproj/project.pbxproj
@@ -126,6 +126,7 @@
 		AB4CBA812C6E09CD009A2AB6 /* SettingType.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB4CBA802C6E09CD009A2AB6 /* SettingType.swift */; };
 		AB4CBA842C6E3320009A2AB6 /* BaseResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB4CBA832C6E3320009A2AB6 /* BaseResponse.swift */; };
 		AB4ECF462C70848C00DC24A0 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = AB4ECF452C70848C00DC24A0 /* Kingfisher */; };
+		AB516B602C7A052C00168EEF /* UserData.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB516B5F2C7A052C00168EEF /* UserData.swift */; };
 		AB5D35502C7759E60028995C /* EditUserInfoRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5D354F2C7759E60028995C /* EditUserInfoRequestDTO.swift */; };
 		AB5D35522C7759F00028995C /* EditUserInfoResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5D35512C7759F00028995C /* EditUserInfoResponseDTO.swift */; };
 		AB5D35552C775AB20028995C /* UserBasicInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5D35542C775AB20028995C /* UserBasicInfo.swift */; };
@@ -308,6 +309,7 @@
 		AB4CBA7A2C6E0755009A2AB6 /* SettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewModel.swift; sourceTree = "<group>"; };
 		AB4CBA802C6E09CD009A2AB6 /* SettingType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingType.swift; sourceTree = "<group>"; };
 		AB4CBA832C6E3320009A2AB6 /* BaseResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseResponse.swift; sourceTree = "<group>"; };
+		AB516B5F2C7A052C00168EEF /* UserData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserData.swift; sourceTree = "<group>"; };
 		AB5D354F2C7759E60028995C /* EditUserInfoRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditUserInfoRequestDTO.swift; sourceTree = "<group>"; };
 		AB5D35512C7759F00028995C /* EditUserInfoResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditUserInfoResponseDTO.swift; sourceTree = "<group>"; };
 		AB5D35542C775AB20028995C /* UserBasicInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserBasicInfo.swift; sourceTree = "<group>"; };
@@ -651,6 +653,7 @@
 				AB22AD3B2C4E8D9D00C9A0F3 /* AppDelegate.swift */,
 				AB22AD3D2C4E8D9D00C9A0F3 /* SceneDelegate.swift */,
 				AB949A2E2C7474580005C543 /* AppFlowController.swift */,
+				AB516B5F2C7A052C00168EEF /* UserData.swift */,
 			);
 			path = Application;
 			sourceTree = "<group>";
@@ -1628,6 +1631,7 @@
 				ABED44192C666F6E0073398A /* GoalChartCell.swift in Sources */,
 				AB2E7BE32C53C17100CE43CB /* CategoryTitleCell.swift in Sources */,
 				AB4CBA6A2C6DD6E3009A2AB6 /* ServerRequestInterceptor.swift in Sources */,
+				AB516B602C7A052C00168EEF /* UserData.swift in Sources */,
 				057925412C4FF4DC00834EC6 /* GoalViewController.swift in Sources */,
 				AB9C5D6E2C78C42A00CE44AF /* LoginResponseDTO.swift in Sources */,
 				AB2E7BED2C53DB2200CE43CB /* BooksWithHeader.swift in Sources */,

--- a/BookTalk/BookTalk/Sources/Application/UserData.swift
+++ b/BookTalk/BookTalk/Sources/Application/UserData.swift
@@ -1,0 +1,40 @@
+//
+//  UserData.swift
+//  BookTalk
+//
+//  Created by 김민 on 8/24/24.
+//
+
+import Foundation
+
+final class UserData {
+    static let shared = UserData()
+
+    private init() {}
+
+    private let key = UserDefaults.Key.userData
+    private let defaults = UserDefaults.standard
+
+    func saveUser(_ user: UserBasicInfo) {
+        do {
+            let data = try JSONEncoder().encode(user)
+            defaults.set(data, forKey: key)
+        } catch {
+            print("유저 저장 실패")
+        }
+    }
+
+    func getUser() -> UserBasicInfo? {
+        guard let data = defaults.data(forKey: key) else {
+            return nil
+        }
+
+        do {
+            let user = try JSONDecoder().decode(UserBasicInfo.self, from: data)
+            return user
+        } catch {
+            print("유저 정보 불러오기 실패")
+            return nil
+        }
+    }
+}

--- a/BookTalk/BookTalk/Sources/DTO/User/Response/EditUserInfoResponseDTO.swift
+++ b/BookTalk/BookTalk/Sources/DTO/User/Response/EditUserInfoResponseDTO.swift
@@ -20,7 +20,7 @@ extension EditUserInfoResponseDTO {
             profileImage: "", // TODO:
             nickname: nickname,
             gender: GenderType(code: gender),
-            birth: birthDate.toKoreanAge()
+            birth: birthDate
         )
     }
 }

--- a/BookTalk/BookTalk/Sources/DTO/User/Response/EditUserInfoResponseDTO.swift
+++ b/BookTalk/BookTalk/Sources/DTO/User/Response/EditUserInfoResponseDTO.swift
@@ -12,3 +12,15 @@ struct EditUserInfoResponseDTO: Decodable {
     let gender: String
     let birthDate: String
 }
+
+extension EditUserInfoResponseDTO {
+
+    func toModel() -> UserBasicInfo {
+        return .init(
+            profileImage: "", // TODO:
+            nickname: nickname,
+            gender: GenderType(code: gender),
+            birth: birthDate.toKoreanAge()
+        )
+    }
+}

--- a/BookTalk/BookTalk/Sources/Model/User/GenderType.swift
+++ b/BookTalk/BookTalk/Sources/Model/User/GenderType.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum GenderType: String {
+enum GenderType: String, Codable {
     case notSelcted = "NOT_SELECTED"
     case man = "MAN"
     case woman = "WOMAN"

--- a/BookTalk/BookTalk/Sources/Model/User/UserBasicInfo.swift
+++ b/BookTalk/BookTalk/Sources/Model/User/UserBasicInfo.swift
@@ -12,9 +12,9 @@ struct UserInfo {
     let dibs: [Book]
 }
 
-struct UserBasicInfo {
+struct UserBasicInfo: Codable {
     let profileImage: String
     let nickname: String
     let gender: GenderType
-    let birth: String // TODO: 나이 계산
+    let birth: String
 }

--- a/BookTalk/BookTalk/Sources/Network/User/UserService.swift
+++ b/BookTalk/BookTalk/Sources/Network/User/UserService.swift
@@ -14,14 +14,18 @@ struct UserService {
             target: UserTarget.getUserInfo
         )
         
-        return result.toModel()
+        let userInfo = result.toModel()
+        
+        UserData.shared.saveUser(userInfo.userInfo)
+
+        return userInfo
     }
 
     static func editUserInfo(
         nickname: String,
         gender: GenderType,
         birthDate: String
-    ) async throws -> EditUserInfoResponseDTO {
+    ) async throws -> UserBasicInfo {
         let body: EditUserInfoRequestDTO = .init(
             nickname: nickname,
             gender: gender.rawValue,
@@ -29,8 +33,11 @@ struct UserService {
         )
 
         let result: EditUserInfoResponseDTO = try await NetworkService.shared.request(target: UserTarget.editUserInfo(body: body))
+        let newUser = result.toModel()
 
-        return result
+        UserData.shared.saveUser(newUser)
+
+        return newUser
     }
 
     static func getFavoriteBooks() async throws -> [Book] {

--- a/BookTalk/BookTalk/Sources/Presentation/Login/View/LoginViewController.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Login/View/LoginViewController.swift
@@ -99,7 +99,8 @@ final class LoginViewController: BaseViewController {
             guard let self = self else { return }
             guard isLoginCompleted else { return }
 
-            let registerVC = UserInfoViewController()
+            let viewModel = UserInfoViewModel(isInitialEdit: true)
+            let registerVC = UserInfoViewController(viewModel: viewModel)
             navigationController?.pushViewController(registerVC, animated: true)
         }
 

--- a/BookTalk/BookTalk/Sources/Presentation/Login/View/LoginViewController.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Login/View/LoginViewController.swift
@@ -99,7 +99,7 @@ final class LoginViewController: BaseViewController {
             guard let self = self else { return }
             guard isLoginCompleted else { return }
 
-            let registerVC = RegistrationViewController()
+            let registerVC = UserInfoViewController()
             navigationController?.pushViewController(registerVC, animated: true)
         }
 

--- a/BookTalk/BookTalk/Sources/Presentation/MyPage/View/MyViewController.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/MyPage/View/MyViewController.swift
@@ -50,7 +50,8 @@ final class MyViewController: BaseViewController {
     // MARK: - Actions
     
     @objc private func editInfoButtonDidTap() {
-        let infoVC = UserInfoViewController()
+        let viewModel = UserInfoViewModel(isInitialEdit: false)
+        let infoVC = UserInfoViewController(viewModel: viewModel)
         infoVC.navigationItem.backButtonTitle = ""
         infoVC.hidesBottomBarWhenPushed = true
 

--- a/BookTalk/BookTalk/Sources/Presentation/MyPage/View/MyViewController.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/MyPage/View/MyViewController.swift
@@ -50,7 +50,7 @@ final class MyViewController: BaseViewController {
     // MARK: - Actions
     
     @objc private func editInfoButtonDidTap() {
-        let infoVC = RegistrationViewController()
+        let infoVC = UserInfoViewController()
         infoVC.navigationItem.backButtonTitle = ""
         infoVC.hidesBottomBarWhenPushed = true
 

--- a/BookTalk/BookTalk/Sources/Presentation/Registration/ViewModel/RegistrationViewModel.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Registration/ViewModel/RegistrationViewModel.swift
@@ -39,11 +39,13 @@ struct RegistrationViewModel {
     ) {
         Task {
             do {
-                _ = try await UserService.editUserInfo(
+                let newUserInfo = try await UserService.editUserInfo(
                     nickname: nickname,
                     gender: gender,
                     birthDate: birth
                 )
+
+                UserData.shared.saveUser(newUserInfo)
 
                 await MainActor.run {
                     UserDefaults.standard.set(true, forKey: UserDefaults.Key.isLoggedIn)

--- a/BookTalk/BookTalk/Sources/Presentation/UserInfo/View/UserInfoViewController.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/UserInfo/View/UserInfoViewController.swift
@@ -1,5 +1,5 @@
 //
-//  RegistrationViewController.swift
+//  UserInfoViewController.swift
 //  BookTalk
 //
 //  Created by RAFA on 8/22/24.
@@ -7,11 +7,11 @@
 
 import UIKit
 
-final class RegistrationViewController: BaseViewController {
-    
+final class UserInfoViewController: BaseViewController {
+
     // MARK: - Properties
     
-    private var viewModel = RegistrationViewModel()
+    private var viewModel = UserInfoViewModel()
     private var isKeyboardAlreadyShown = false
     
     private let addPhotoButton = UIButton(type: .system)
@@ -324,8 +324,8 @@ final class RegistrationViewController: BaseViewController {
 
 // MARK: - UIImagePickerControllerDelegate
 
-extension RegistrationViewController: UIImagePickerControllerDelegate {
-    
+extension UserInfoViewController: UIImagePickerControllerDelegate {
+
     func imagePickerController(
         _ picker: UIImagePickerController,
         didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]
@@ -354,8 +354,8 @@ extension RegistrationViewController: UIImagePickerControllerDelegate {
 
 // MARK: - UINavigationControllerDelegate
 
-extension RegistrationViewController: UINavigationControllerDelegate {
-    
+extension UserInfoViewController: UINavigationControllerDelegate {
+
     private func presentImagePickerActionSheet() {
         let actionSheet = UIAlertController(
             title: "사진 선택",
@@ -394,7 +394,7 @@ extension RegistrationViewController: UINavigationControllerDelegate {
 
 // MARK: - UITextFieldDelegate
 
-extension RegistrationViewController: UITextFieldDelegate {
+extension UserInfoViewController: UITextFieldDelegate {
     
     func textField(
         _ textField: UITextField,
@@ -407,7 +407,7 @@ extension RegistrationViewController: UITextFieldDelegate {
 
 // MARK: - Set UI Helpers
 
-private extension RegistrationViewController {
+private extension UserInfoViewController {
 
     func setupTextField(textField: UITextField, placeholder: String? = nil, spacerWidth: CGFloat) {
         textField.do {

--- a/BookTalk/BookTalk/Sources/Presentation/UserInfo/View/UserInfoViewController.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/UserInfo/View/UserInfoViewController.swift
@@ -177,6 +177,12 @@ final class UserInfoViewController: BaseViewController {
         viewModel.isFormValid.subscribe { [weak self] isValid in
             self?.updateSignUpButtonState(isValid: isValid)
         }
+
+        viewModel.popToMyPage.subscribe { [weak self] isCompleted in
+            guard isCompleted else { return }
+
+            self?.navigationController?.popViewController(animated: true)
+        }
     }
     
     // MARK: - Helpers

--- a/BookTalk/BookTalk/Sources/Presentation/UserInfo/View/UserInfoViewController.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/UserInfo/View/UserInfoViewController.swift
@@ -11,9 +11,6 @@ final class UserInfoViewController: BaseViewController {
 
     // MARK: - Properties
     
-    private var viewModel = UserInfoViewModel()
-    private var isKeyboardAlreadyShown = false
-    
     private let addPhotoButton = UIButton(type: .system)
     private let nicknameTextField = UITextField()
     private let maleButton = UIButton(type: .system)
@@ -24,6 +21,20 @@ final class UserInfoViewController: BaseViewController {
     private let signUpButton = UIButton(type: .system)
     private let credentialsStackView = UIStackView()
 
+    // MARK: - Initializer
+
+    private var viewModel: UserInfoViewModel
+
+    init(viewModel: UserInfoViewModel) {
+        self.viewModel = viewModel
+
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     // MARK: - Lifecycle
 
     override func viewDidLoad() {
@@ -395,7 +406,7 @@ extension UserInfoViewController: UINavigationControllerDelegate {
 // MARK: - UITextFieldDelegate
 
 extension UserInfoViewController: UITextFieldDelegate {
-    
+
     func textField(
         _ textField: UITextField,
         shouldChangeCharactersIn range: NSRange,

--- a/BookTalk/BookTalk/Sources/Presentation/UserInfo/View/UserInfoViewController.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/UserInfo/View/UserInfoViewController.swift
@@ -283,7 +283,11 @@ final class UserInfoViewController: BaseViewController {
             $0.datePickerMode = .date
             $0.preferredDatePickerStyle = .wheels
             $0.locale = .init(identifier: "ko-KR")
-            $0.maximumDate = Date()
+            $0.maximumDate = Calendar.current.date(
+                byAdding: .day,
+                value: -1,
+                to: Date()
+            )
         }
         
         signUpButton.do {

--- a/BookTalk/BookTalk/Sources/Presentation/UserInfo/ViewModel/UserInfoViewModel.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/UserInfo/ViewModel/UserInfoViewModel.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-struct RegistrationViewModel {
+struct UserInfoViewModel {
     
     let nickname = Observable<String>("")
     let selectedGender = Observable<GenderType?>(nil)

--- a/BookTalk/BookTalk/Sources/Presentation/UserInfo/ViewModel/UserInfoViewModel.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/UserInfo/ViewModel/UserInfoViewModel.swift
@@ -8,12 +8,22 @@
 import UIKit
 
 struct UserInfoViewModel {
-    
+
+    // MARK: - Properties
+
     let nickname = Observable<String>("")
     let selectedGender = Observable<GenderType?>(nil)
     let birthDate = Observable<Date?>(nil)
     let isFormValid = Observable<Bool>(false)
     let pushToHomeView = Observable<Bool>(false)
+
+    private let isInitialEdit: Bool
+
+    // MARK: - Initializer
+
+    init(isInitialEdit: Bool) {
+        self.isInitialEdit = isInitialEdit
+    }
 
     // MARK: - Actions
     

--- a/BookTalk/BookTalk/Sources/Presentation/UserInfo/ViewModel/UserInfoViewModel.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/UserInfo/ViewModel/UserInfoViewModel.swift
@@ -23,10 +23,24 @@ struct UserInfoViewModel {
 
     init(isInitialEdit: Bool) {
         self.isInitialEdit = isInitialEdit
+
+        setUserInfoIfNeeded()
     }
 
     // MARK: - Actions
-    
+
+    private func setUserInfoIfNeeded() {
+        guard !isInitialEdit else { return }
+
+        let oldUserInfo = UserData.shared.getUser()
+        guard let oldUserInfo = oldUserInfo else { return }
+
+        nickname.value = oldUserInfo.nickname
+        selectedGender.value = oldUserInfo.gender
+        birthDate.value = oldUserInfo.birth.toDate()
+    }
+
+
     func updateNickname(_ text: String) {
         nickname.value = text
         validateForm()
@@ -49,7 +63,7 @@ struct UserInfoViewModel {
     ) {
         Task {
             do {
-                let newUserInfo = try await UserService.editUserInfo(
+                let _ = try await UserService.editUserInfo(
                     nickname: nickname,
                     gender: gender,
                     birthDate: birth

--- a/BookTalk/BookTalk/Sources/Presentation/UserInfo/ViewModel/UserInfoViewModel.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/UserInfo/ViewModel/UserInfoViewModel.swift
@@ -11,11 +11,11 @@ struct UserInfoViewModel {
 
     // MARK: - Properties
 
-    let nickname = Observable<String>("")
-    let selectedGender = Observable<GenderType?>(nil)
-    let birthDate = Observable<Date?>(nil)
-    let isFormValid = Observable<Bool>(false)
-    let pushToHomeView = Observable<Bool>(false)
+    private(set) var nickname = Observable<String>("")
+    private(set) var selectedGender = Observable<GenderType?>(nil)
+    private(set) var birthDate = Observable<Date?>(nil)
+    private(set) var isFormValid = Observable<Bool>(false)
+    private(set) var popToMyPage = Observable<Bool>(false)
 
     private let isInitialEdit: Bool
 
@@ -55,14 +55,16 @@ struct UserInfoViewModel {
                     birthDate: birth
                 )
 
-                UserData.shared.saveUser(newUserInfo)
-
                 await MainActor.run {
-                    UserDefaults.standard.set(true, forKey: UserDefaults.Key.isLoggedIn)
-                    NotificationCenter.default.post(
-                        name: Notification.Name.authStateChanged,
-                        object: nil
-                    )
+                    if isInitialEdit {
+                        UserDefaults.standard.set(true, forKey: UserDefaults.Key.isLoggedIn)
+                        NotificationCenter.default.post(
+                            name: Notification.Name.authStateChanged,
+                            object: nil
+                        )
+                    } else {
+                        popToMyPage.value.toggle()
+                    }
                 }
             } catch let error as NetworkError {
                 print(error.localizedDescription)

--- a/BookTalk/BookTalk/Sources/Util/Extension/String+.swift
+++ b/BookTalk/BookTalk/Sources/Util/Extension/String+.swift
@@ -33,4 +33,13 @@ extension String {
 
         return "\(koreanAge)"
     }
+
+    func toDate() -> Date? {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        dateFormatter.locale = Locale(identifier: "ko_KR")
+        dateFormatter.timeZone = TimeZone(secondsFromGMT: 0) 
+
+        return dateFormatter.date(from: self)
+    }
 }

--- a/BookTalk/BookTalk/Sources/Util/Extension/UserDefaults+.swift
+++ b/BookTalk/BookTalk/Sources/Util/Extension/UserDefaults+.swift
@@ -11,5 +11,6 @@ extension UserDefaults {
 
     struct Key {
         static let isLoggedIn = "isLoggedIn"
+        static let userData = "userData"
     }
 }


### PR DESCRIPTION
## 📚 PR 요약
유저 정보 조회 api 연결 및 저장

## 📝 작업 내용
- 정보 수정 로직 추가
- 유저가 정보를 조회, 수정할 때마다 UserDefault로 저장
- 정보 등록이 아닌 수정 시에는 기본값 제공

## 📌 참고 사항
- 앱 사용 시 필요한 유저 정보가 있을 시 `UserData` 

## 📷 Screenshot

https://github.com/user-attachments/assets/4aa0fe3a-5ac8-415e-8645-2c04411487a0


## 📮 관련 이슈
- Resolved: #125 
