### PR TITLE
[style] 프로필 이미지 제거

### DIFF
--- a/BookTalk/BookTalk/Sources/Presentation/MyPage/Header/ProfileInfoView.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/MyPage/Header/ProfileInfoView.swift
@@ -15,8 +15,7 @@ protocol ProfileInfoViewDelegate: AnyObject {
 final class ProfileInfoView: BaseCollectionViewHeaderFooterView {
     
     // MARK: - Properties
-
-    private let profileImageView = UIImageView()
+    
     private let nameLabel = UILabel()
     private let genderAndAgeLabel = UILabel()
     private let userInfoStackView = UIStackView()
@@ -33,7 +32,6 @@ final class ProfileInfoView: BaseCollectionViewHeaderFooterView {
         super.init(frame: frame)
         
         addTargets()
-        addGestureRecognizers()
     }
     
     required init?(coder: NSCoder) {
@@ -50,14 +48,6 @@ final class ProfileInfoView: BaseCollectionViewHeaderFooterView {
         delegate?.didTapEditLibraryButton()
     }
     
-    @objc private func imageViewTapped() {
-        let fullScreen = FullScreenViewController()
-        fullScreen.modalTransitionStyle = .crossDissolve
-        fullScreen.modalPresentationStyle = .overFullScreen
-        fullScreen.image = profileImageView.image
-        window?.rootViewController?.present(fullScreen, animated: true)
-    }
-    
     private func addTargets() {
         addFinishedBookButton.addTarget(
             self,
@@ -71,11 +61,6 @@ final class ProfileInfoView: BaseCollectionViewHeaderFooterView {
         )
     }
     
-    private func addGestureRecognizers() {
-        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(imageViewTapped))
-        profileImageView.addGestureRecognizer(tapGesture)
-    }
-    
     // MARK: - Bind
     
     func bind(with userInfo: UserBasicInfo?) {
@@ -83,12 +68,6 @@ final class ProfileInfoView: BaseCollectionViewHeaderFooterView {
         
         nameLabel.text = userInfo.nickname
         genderAndAgeLabel.text = "\(userInfo.gender.koreanTitle)/\(userInfo.birth.toKoreanAge())"
-
-        if let url = URL(string: userInfo.profileImage) {
-            profileImageView.kf.setImage(with: url)
-        } else {
-            profileImageView.image = nil
-        }
     }
     
     // MARK: - Helpers
@@ -115,35 +94,23 @@ final class ProfileInfoView: BaseCollectionViewHeaderFooterView {
     // MARK: - Set UI
     
     override func setViews() {
-        profileImageView.do {
-            $0.clipsToBounds = true
-            $0.layer.cornerRadius = 180 / 2
-            $0.backgroundColor = .gray100
-            $0.tintColor = .white
-            $0.contentMode = .scaleAspectFill
-            $0.isUserInteractionEnabled = true
-        }
-        
         nameLabel.do {
-            $0.font = .systemFont(ofSize: 23, weight: .bold)
-            $0.numberOfLines = 1
-            $0.lineBreakMode = .byTruncatingTail
-            $0.setContentHuggingPriority(.defaultLow, for: .horizontal)
-            $0.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+            $0.font = .systemFont(ofSize: 30, weight: .bold)
+            $0.numberOfLines = 0
+            $0.textAlignment = .center
         }
         
         genderAndAgeLabel.do {
             $0.textColor = .lightGray
-            $0.font = .systemFont(ofSize: 15, weight: .medium)
+            $0.font = .systemFont(ofSize: 20, weight: .medium)
             $0.numberOfLines = 1
-            $0.setContentHuggingPriority(.required, for: .horizontal)
-            $0.setContentCompressionResistancePriority(.required, for: .horizontal)
+            $0.textAlignment = .center
         }
         
         userInfoStackView.do {
             $0.addArrangedSubview(nameLabel)
             $0.addArrangedSubview(genderAndAgeLabel)
-            $0.axis = .horizontal
+            $0.axis = .vertical
             $0.alignment = .fill
             $0.distribution = .fillProportionally
             $0.spacing = 5
@@ -204,20 +171,14 @@ final class ProfileInfoView: BaseCollectionViewHeaderFooterView {
     }
     
     override func setConstraints() {
-        [profileImageView, userInfoStackView, libraryTextStackView,  profileBottomButtons].forEach {
+        [userInfoStackView, libraryTextStackView,  profileBottomButtons].forEach {
             addSubview($0)
         }
         
-        profileImageView.snp.makeConstraints {
-            $0.centerX.equalToSuperview()
-            $0.top.equalTo(self.safeAreaLayoutGuide.snp.top).offset(10)
-            $0.size.equalTo(180)
-        }
-        
         userInfoStackView.snp.makeConstraints {
-            $0.centerX.equalTo(profileImageView)
-            $0.top.equalTo(profileImageView.snp.bottom).offset(5)
-            $0.left.greaterThanOrEqualTo(15)
+            $0.centerX.equalToSuperview()
+            $0.top.equalTo(self.safeAreaLayoutGuide.snp.top).offset(20)
+            $0.left.equalTo(15)
         }
         
         libraryTextStackView.snp.makeConstraints {

--- a/BookTalk/BookTalk/Sources/Presentation/MyPage/View/MyViewController.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/MyPage/View/MyViewController.swift
@@ -301,7 +301,7 @@ private extension MyViewController {
     static func createProfileHeaderItem() -> NSCollectionLayoutBoundarySupplementaryItem {
         let headerSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1.0),
-            heightDimension: .estimated(270)
+            heightDimension: .estimated(150)
         )
         
         return NSCollectionLayoutBoundarySupplementaryItem(
@@ -320,7 +320,7 @@ private extension MyViewController {
         
         let groupSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1.0),
-            heightDimension: .estimated(270)
+            heightDimension: .estimated(150)
         )
         let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
         

--- a/BookTalk/BookTalk/Sources/Presentation/OpenTalk/Cell/TableViewCell/OtherChatBubbleCell.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/OpenTalk/Cell/TableViewCell/OtherChatBubbleCell.swift
@@ -10,28 +10,17 @@ import UIKit
 final class OtherChatBubbleCell: BaseTableViewCell {
 
     // MARK: - Properties
-
-    private let profileImageView = UIImageView()
+    
     private let nicknameLabel = UILabel()
     private let chatMessageLabel = UILabel()
     private let bubbleView = UIView()
 
     // MARK: - UI Setup
 
-    override func layoutSubviews() {
-        profileImageView.layer.cornerRadius = profileImageView.frame.height / 2
-    }
-
     override func setViews() {
         selectionStyle = .none
 
         backgroundColor = .clear
-
-        profileImageView.do {
-            $0.backgroundColor = .gray100
-            $0.layer.masksToBounds = false
-            $0.clipsToBounds = true
-        }
 
         nicknameLabel.do {
             $0.font = .systemFont(ofSize: 13, weight: .regular)
@@ -52,21 +41,15 @@ final class OtherChatBubbleCell: BaseTableViewCell {
     }
 
     override func setConstraints() {
-        [profileImageView, nicknameLabel, bubbleView].forEach {
+        [nicknameLabel, bubbleView].forEach {
             contentView.addSubview($0)
         }
 
         bubbleView.addSubview(chatMessageLabel)
 
-        profileImageView.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(12)
-            $0.leading.equalToSuperview().offset(16)
-            $0.width.height.equalTo(40)
-        }
-
         nicknameLabel.snp.makeConstraints {
-            $0.top.equalTo(profileImageView).offset(4)
-            $0.leading.equalTo(profileImageView.snp.trailing).offset(12)
+            $0.top.equalTo(contentView.safeAreaLayoutGuide.snp.top).offset(16)
+            $0.leading.equalTo(16)
         }
 
         bubbleView.snp.makeConstraints {

--- a/BookTalk/BookTalk/Sources/Presentation/UserInfo/View/UserInfoViewController.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/UserInfo/View/UserInfoViewController.swift
@@ -11,7 +11,6 @@ final class UserInfoViewController: BaseViewController {
 
     // MARK: - Properties
     
-    private let addPhotoButton = UIButton(type: .system)
     private let nicknameTextField = UITextField()
     private let maleButton = UIButton(type: .system)
     private let femaleButton = UIButton(type: .system)
@@ -55,10 +54,6 @@ final class UserInfoViewController: BaseViewController {
     }
     
     // MARK: - Actions
-    
-    @objc private func addPhotoButtonTapped() {
-        presentImagePickerActionSheet()
-    }
     
     @objc private func nicknameChanged() {
         viewModel.updateNickname(nicknameTextField.text ?? "")
@@ -117,11 +112,6 @@ final class UserInfoViewController: BaseViewController {
     }
     
     private func addTargets() {
-        addPhotoButton.addTarget(
-            self,
-            action: #selector(addPhotoButtonTapped),
-            for: .touchUpInside
-        )
         nicknameTextField.addTarget(
             self,
             action: #selector(nicknameChanged),
@@ -241,21 +231,6 @@ final class UserInfoViewController: BaseViewController {
     override func setViews() {
         view.backgroundColor = .white
         
-        addPhotoButton.do {
-            $0.setImage(
-                UIImage(systemName: "plus")?
-                    .withTintColor(.gray100, renderingMode: .alwaysOriginal)
-                    .withConfiguration(
-                        UIImage.SymbolConfiguration(pointSize: 20, weight: .light)
-                    ),
-                for: .normal
-            )
-            $0.layer.cornerRadius = 150 / 2
-            $0.layer.masksToBounds = true
-            $0.layer.borderWidth = 1
-            $0.layer.borderColor = UIColor.gray100.cgColor
-        }
-        
         setupTextField(
             textField: nicknameTextField,
             placeholder: "닉네임 (한글 2자 이상, 영어 3자 이상)",
@@ -315,14 +290,7 @@ final class UserInfoViewController: BaseViewController {
     }
     
     override func setConstraints() {
-        [addPhotoButton,
-         credentialsStackView].forEach { view.addSubview($0) }
-        
-        addPhotoButton.snp.makeConstraints {
-            $0.centerX.equalToSuperview()
-            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(20)
-            $0.size.equalTo(150)
-        }
+        [credentialsStackView].forEach { view.addSubview($0) }
         
         nicknameTextField.snp.makeConstraints {
             $0.height.equalTo(50)
@@ -333,10 +301,10 @@ final class UserInfoViewController: BaseViewController {
         }
         
         credentialsStackView.snp.makeConstraints {
-            $0.centerX.equalTo(addPhotoButton)
-            $0.top.lessThanOrEqualTo(addPhotoButton.snp.bottom).offset(50)
+            $0.centerX.equalToSuperview()
+            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(30)
             $0.left.equalTo(10)
-            $0.bottom.equalTo(view.keyboardLayoutGuide.snp.top).offset(-20)
+            $0.bottom.greaterThanOrEqualTo(view.keyboardLayoutGuide.snp.top).offset(-20)
         }
         
         birthTextField.snp.makeConstraints {
@@ -346,76 +314,6 @@ final class UserInfoViewController: BaseViewController {
         signUpButton.snp.makeConstraints {
             $0.height.equalTo(50)
         }
-    }
-}
-
-// MARK: - UIImagePickerControllerDelegate
-
-extension UserInfoViewController: UIImagePickerControllerDelegate {
-
-    func imagePickerController(
-        _ picker: UIImagePickerController,
-        didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]
-    ) {
-        if let editedImage = info[.editedImage] as? UIImage {
-            addPhotoButton.setImage(
-                editedImage.withRenderingMode(.alwaysOriginal),
-                for: .normal
-            )
-        } else if let originalImage = info[.originalImage] as? UIImage {
-            addPhotoButton.setImage(
-                originalImage.withRenderingMode(.alwaysOriginal),
-                for: .normal
-            )
-        }
-        
-        addPhotoButton.layer.borderColor = UIColor.clear.cgColor
-        addPhotoButton.contentMode = .scaleAspectFill
-        dismiss(animated: true, completion: nil)
-    }
-    
-    func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
-        dismiss(animated: true, completion: nil)
-    }
-}
-
-// MARK: - UINavigationControllerDelegate
-
-extension UserInfoViewController: UINavigationControllerDelegate {
-
-    private func presentImagePickerActionSheet() {
-        let actionSheet = UIAlertController(
-            title: "사진 선택",
-            message: "프로필 사진을 선택하세요.",
-            preferredStyle: .actionSheet
-        )
-        
-        let cameraAction = UIAlertAction(title: "카메라", style: .default) { _ in
-            self.presentImagePicker(sourceType: .camera)
-        }
-        
-        let libraryAction = UIAlertAction(title: "사진 앨범", style: .default) { _ in
-            self.presentImagePicker(sourceType: .photoLibrary)
-        }
-        
-        let cancelAction = UIAlertAction(title: "취소", style: .cancel, handler: nil)
-        
-        actionSheet.addAction(cameraAction)
-        actionSheet.addAction(libraryAction)
-        actionSheet.addAction(cancelAction)
-        
-        present(actionSheet, animated: true, completion: nil)
-    }
-    
-    private func presentImagePicker(sourceType: UIImagePickerController.SourceType) {
-        guard UIImagePickerController.isSourceTypeAvailable(sourceType) else { return }
-        
-        let imagePicker = UIImagePickerController()
-        imagePicker.sourceType = sourceType
-        imagePicker.delegate = self
-        imagePicker.allowsEditing = true
-        
-        present(imagePicker, animated: true, completion: nil)
     }
 }
 


### PR DESCRIPTION
## 📚 PR 요약
프로필 이미지 제거(임시)

## 📝 작업 내용
- 정보 등록에 프로필 이미지 등록 버튼 제거
- 마이페이지 프로필 이미지 제거
- 채팅에서 프로필 이미지 제거

## 📌 참고 사항


## 📷 Screenshot
| 정보 등록 | 마이페이지 | 오픈톡 |
| -- | -- | -- |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-08-26 at 05 40 41](https://github.com/user-attachments/assets/6a924bce-7055-4acd-a20c-c94084957b40) | ![Simulator Screenshot - iPhone 15 Pro - 2024-08-26 at 05 40 45](https://github.com/user-attachments/assets/b48c02e7-1ca1-4c63-9154-e87b39ffa4e9) | ![Simulator Screenshot - iPhone 15 Pro - 2024-08-26 at 05 40 53](https://github.com/user-attachments/assets/10b1049e-fbf2-44cf-890f-3467daf6fa22) |

## 📮 관련 이슈
- Resolved: #151 
