### PR TITLE
[feat] 닉네임 글자 수 제한

### DIFF
--- a/BookTalk/BookTalk/Sources/Presentation/UserInfo/View/UserInfoViewController.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/UserInfo/View/UserInfoViewController.swift
@@ -251,7 +251,7 @@ final class UserInfoViewController: BaseViewController {
         
         setupTextField(
             textField: nicknameTextField,
-            placeholder: "닉네임 (한글 2자 이상, 영어 3자 이상) - 필수",
+            placeholder: "닉네임 (한글 2자~8자, 영어 3자~16자) - 필수",
             spacerWidth: 12
         )
         

--- a/BookTalk/BookTalk/Sources/Presentation/UserInfo/ViewModel/UserInfoViewModel.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/UserInfo/ViewModel/UserInfoViewModel.swift
@@ -106,9 +106,9 @@ struct UserInfoViewModel {
         guard !nickname.value.isEmpty else { return false }
         
         if isKorean(nickname.value) {
-            return nickname.value.count >= 2
+            return nickname.value.count >= 2 && nickname.value.count <= 8
         } else {
-            return nickname.value.count >= 3
+            return nickname.value.count >= 3 && nickname.value.count <= 16
         }
     }
     


### PR DESCRIPTION
## 📚 PR 요약
닉네임 글자 수 제한

## 📝 작업 내용
- 영어 최대 16자, 한글 최대 8자만 입력할 수 있도록 수정
- 닉네임 텍스트필드 플레이스홀더 수정

## 📌 참고 사항


## 📷 Screenshot


## 📮 관련 이슈
- Resolved: #181 
