### PR TITLE
[fix] 오픈톡 관련 오류 해결

### DIFF
--- a/BookTalk/BookTalk.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/BookTalk/BookTalk.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -25,7 +25,7 @@
       "location" : "https://github.com/kakao/kakao-ios-sdk",
       "state" : {
         "branch" : "master",
-        "revision" : "66b3bddc2657e8ccb7a16fa0264aac99c57be09b"
+        "revision" : "f50278451e3ea7e131fb94e08e3fe86023d84930"
       }
     },
     {

--- a/BookTalk/BookTalk/Sources/Presentation/Login/ViewModel/LoginViewModel.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Login/ViewModel/LoginViewModel.swift
@@ -167,7 +167,7 @@ final class LoginViewModel {
         do {
             let userInfo = try await UserService.getUserInfo()
 
-            return userInfo.userInfo.nickname != nil
+            return !userInfo.userInfo.nickname.isEmpty
         } catch let error as NetworkError {
             print(error.localizedDescription)
             return false

--- a/BookTalk/BookTalk/Sources/Presentation/MyPage/ViewModel/MyViewModel.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/MyPage/ViewModel/MyViewModel.swift
@@ -31,10 +31,8 @@ final class MyPageViewModel {
                     dibBooksOb.value = userInfo.dibs
                     readBooksOb.value = userInfo.readBooks
 
-                    // TODO: 읽은 책 추가
-
                 } catch let error as NetworkError {
-                   
+                    print(error.localizedDescription)
                 }
             }
         }

--- a/BookTalk/BookTalk/Sources/Presentation/OpenTalk/Cell/CollectionViewCell/OpenTalkPageCell.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/OpenTalk/Cell/CollectionViewCell/OpenTalkPageCell.swift
@@ -49,7 +49,7 @@ final class OpenTalkPageCell: BaseCollectionViewCell {
         lineView.snp.makeConstraints {
             $0.leading.trailing.equalTo(contentView.safeAreaLayoutGuide)
             $0.bottom.equalTo(contentView)
-            $0.height.equalTo(1)
+            $0.height.equalTo(2)
         }
     }
 

--- a/BookTalk/BookTalk/Sources/Presentation/OpenTalk/View/OpenTalkViewController.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/OpenTalk/View/OpenTalkViewController.swift
@@ -14,7 +14,6 @@ final class OpenTalkViewController: BaseViewController {
     private let bookBanner = UIImageView()
     private let pageCollectionView = UICollectionView(frame: .zero, collectionViewLayout: .init())
     private let bookCollectionView = UICollectionView(frame: .zero, collectionViewLayout: .init())
-    private let refreshControl = UIRefreshControl()
     private let indicatorView = UIActivityIndicatorView(style: .medium)
 
     private let viewModel: OpenTalkViewModel
@@ -39,7 +38,6 @@ final class OpenTalkViewController: BaseViewController {
         setDelegate()
         registerCell()
         bind()
-        addTarget()
 
         viewModel.send(action: .setPageType(.hot))
     }
@@ -87,7 +85,6 @@ final class OpenTalkViewController: BaseViewController {
             $0.backgroundColor = .clear
             $0.contentInset = .init(top: 10, left: 10, bottom: 10, right: 10)
             $0.showsVerticalScrollIndicator = false
-            $0.refreshControl = refreshControl
         }
 
         indicatorView.do {
@@ -142,14 +139,6 @@ final class OpenTalkViewController: BaseViewController {
         )
     }
 
-    private func addTarget() {
-        refreshControl.addTarget(
-            self,
-            action: #selector(refreshCollectionView),
-            for: .valueChanged
-        )
-    }
-
     private func bind() {
         viewModel.loadState.subscribe { [weak self] state in
             guard let self = self else { return }
@@ -194,12 +183,6 @@ final class OpenTalkViewController: BaseViewController {
 
         searchVC.hidesBottomBarWhenPushed = true
         navigationController?.pushViewController(searchVC, animated: true)
-    }
-
-    @objc private func refreshCollectionView() {
-        viewModel.send(action: .setPageType(.hot))
-
-        refreshControl.endRefreshing()
     }
 }
 

--- a/BookTalk/BookTalk/Sources/Presentation/OpenTalk/View/OpenTalkViewController.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/OpenTalk/View/OpenTalkViewController.swift
@@ -72,6 +72,7 @@ final class OpenTalkViewController: BaseViewController {
             flowLayout.scrollDirection = .horizontal
 
             $0.collectionViewLayout = flowLayout
+            $0.isScrollEnabled = false
             $0.backgroundColor = .clear
             $0.contentInset = .init()
         }

--- a/BookTalk/BookTalk/Sources/Presentation/OpenTalk/ViewModel/ChatViewModel.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/OpenTalk/ViewModel/ChatViewModel.swift
@@ -138,6 +138,8 @@ final class ChatViewModel {
 
                 await MainActor.run {
                     isBookmarked.value = true
+
+                    NotificationCenter.default.post(name: .openTalkChanged, object: nil)
                 }
             } catch let error as NetworkError {
                 print(error.localizedDescription)
@@ -152,6 +154,8 @@ final class ChatViewModel {
 
                 await MainActor.run {
                     isBookmarked.value = false
+
+                    NotificationCenter.default.post(name: .openTalkChanged, object: nil)
                 }
             } catch let error as NetworkError {
                 print(error.localizedDescription)

--- a/BookTalk/BookTalk/Sources/Presentation/OpenTalk/ViewModel/OpenTalkViewModel.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/OpenTalk/ViewModel/OpenTalkViewModel.swift
@@ -27,9 +27,6 @@ final class OpenTalkViewModel {
         case let .setPageType(selectedPage):
             selectedPageType = selectedPage
 
-            favoriteOpenTalks.value.removeAll()
-            hotOpenTalks.value.removeAll()
-
             switch selectedPage {
             case .hot:
                 loadHotOpenTalk()

--- a/BookTalk/BookTalk/Sources/Presentation/OpenTalk/ViewModel/OpenTalkViewModel.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/OpenTalk/ViewModel/OpenTalkViewModel.swift
@@ -5,6 +5,7 @@
 //  Created by 김민 on 8/20/24.
 //
 
+import Combine
 import Foundation
 
 final class OpenTalkViewModel {
@@ -16,7 +17,23 @@ final class OpenTalkViewModel {
     var favoriteOpenTalks = Observable<[OpenTalkBookModel]>([])
     var loadState = Observable(LoadState.initial)
 
+    private var cancellables = Set<AnyCancellable>()
+
+    // MARK: - Initializer
+
+    init() {
+        bind()
+    }
+
     // MARK: - Helpers
+
+    private func bind() {
+        NotificationCenter.default.publisher(for: .openTalkChanged)
+            .sink { [weak self] _ in
+                self?.loadFavoriteOpenTalk()
+            }
+            .store(in: &cancellables)
+    }
 
     enum Action {
         case setPageType(_ pageType: OpenTalkPageType)

--- a/BookTalk/BookTalk/Sources/Util/Extension/NotificationCenter+.swift
+++ b/BookTalk/BookTalk/Sources/Util/Extension/NotificationCenter+.swift
@@ -13,4 +13,5 @@ extension Notification.Name {
     static let goalChanged = Notification.Name(rawValue: "goalChanged")
     static let progressChanged = Notification.Name(rawValue: "progressChanged")
     static let detailChanged = Notification.Name(rawValue: "detailChanged")
+    static let openTalkChanged = Notification.Name(rawValue: "openTalkChanged")
 }


### PR DESCRIPTION
## 📚 PR 요약
오픈톡 관련 오류 해결

## 📝 작업 내용
- 핫한 오픈톡 / 즐겨찾기한 오픈톡 버튼을 누를 때마다 새로고침하도록 설정되어 있어서 리프레시 기능은 삭제했습니다!
- 채팅창에서 오픈톡 즐찾 설정 / 해제하면 즐겨찾기한 오픈톡이 새로 로드되도록 했습니다.
- 오픈톡 스크롤되던 오류 해결했습니다!

## 📮 관련 이슈
- Resolved: #186 
