### PR TITLE
[feat] 채팅 사이드메뉴뷰에서 목표 생성 시 로직 개선

### DIFF
--- a/BookTalk/BookTalk/Sources/Network/Goal/GoalService.swift
+++ b/BookTalk/BookTalk/Sources/Network/Goal/GoalService.swift
@@ -9,12 +9,14 @@ import Foundation
 
 struct GoalService {
 
-    static func createGoal(with isbn: String, totalPage: Int) async throws {
+    static func createGoal(with isbn: String, totalPage: Int) async throws -> GoalDetailModel {
         let params: CreateGoalRequestDTO = .init(isbn: isbn, totalPage: totalPage)
 
-        let _: GoalResponseDTO = try await NetworkService.shared.request(
+        let result: GoalResponseDTO = try await NetworkService.shared.request(
             target: GoalTarget.postGoalCreate(params: params)
         )
+
+        return result.toModel()
     }
 
     static func getGoalDetail(of goalId: Int) async throws -> GoalDetailModel {

--- a/BookTalk/BookTalk/Sources/Presentation/OpenTalk/View/ChatMenuViewController.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/OpenTalk/View/ChatMenuViewController.swift
@@ -61,6 +61,17 @@ final class ChatMenuViewController: BaseViewController {
                 }
             }
         }
+
+        viewModel.createGoalSucceed.subscribe { isSucceed in
+            guard isSucceed else { return }
+
+            DispatchQueue.main.async { [weak self] in
+                guard let self = self else { return }
+                guard let goalId = viewModel.createdGoalId else { return }
+
+                pushToDetailGoalViewController(goalId: goalId)
+            }
+        }
     }
 
     // MARK: - UI Setup
@@ -129,9 +140,8 @@ final class ChatMenuViewController: BaseViewController {
         )
     }
 
-    private func pushToDetailGoalViewController() {
-        // TODO: goalId 수정
-        let viewModel = DetailGoalViewModel(goalId: 7)
+    private func pushToDetailGoalViewController(goalId: Int) {
+        let viewModel = DetailGoalViewModel(goalId: goalId)
         let detailGoalVC = DetailGoalViewController(viewModel: viewModel)
 
         navigationController?.pushViewController(detailGoalVC, animated: true)
@@ -167,9 +177,13 @@ final class ChatMenuViewController: BaseViewController {
             handler: nil
         )
 
-        let okAction = UIAlertAction(title: "완료", style: .default) { _ in
+        let okAction = UIAlertAction(title: "완료", style: .default) { [weak self] _ in
+            guard let self = self else { return }
+            
             if let textField = alertVC.textFields?.first {
-                print(textField)
+                viewModel.send(
+                    action: .addGoal(isbn: viewModel.isbn, totalPage: textField.text ?? "0")
+                )
             }
         }
 
@@ -233,12 +247,6 @@ extension ChatMenuViewController: UITableViewDataSource {
         case .myProgress:
             if let rate = viewModel.myProgress.value?.progressRate {
                 readingProgressCell.bind(percent: Int(rate))
-
-                readingProgressCell.updateButtonDidTappedObservable.subscribe { [weak self] isTapped in
-                    guard isTapped else { return }
-
-                    self?.pushToDetailGoalViewController()
-                }
 
                 return readingProgressCell
             } else {

--- a/BookTalk/BookTalk/Sources/Presentation/OpenTalk/View/ChatMenuViewController.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/OpenTalk/View/ChatMenuViewController.swift
@@ -143,6 +143,50 @@ final class ChatMenuViewController: BaseViewController {
 
         navigationController?.pushViewController(addBookVC, animated: true)
     }
+
+    private func configureCreateGoalAlert() {
+        let alertVC = UIAlertController(
+            title: "목표 추가",
+            message: "총 페이지 수를 입력해 주세요.",
+            preferredStyle: .alert
+        )
+
+        alertVC.addTextField { tf in
+            tf.placeholder = "페이지 수"
+            tf.keyboardType = .numberPad
+            tf.addTarget(
+                self,
+                action: #selector(self.textDidChange(_:)),
+                for: .editingChanged
+            )
+        }
+
+        let cancelAction = UIAlertAction(
+            title: "취소",
+            style: .cancel,
+            handler: nil
+        )
+
+        let okAction = UIAlertAction(title: "완료", style: .default) { _ in
+            if let textField = alertVC.textFields?.first {
+                print(textField)
+            }
+        }
+
+        okAction.isEnabled = false
+
+        [cancelAction, okAction].forEach { alertVC.addAction($0) }
+
+        present(alertVC, animated: true)
+    }
+
+    @objc private func textDidChange(_ textField: UITextField) {
+        guard let alertVC = self.presentedViewController as? UIAlertController,
+              let okAction = alertVC.actions.last else {
+            return
+        }
+        okAction.isEnabled = !(textField.text?.isEmpty ?? true)
+    }
 }
 
 // MARK: - UITableViewDataSource
@@ -201,7 +245,7 @@ extension ChatMenuViewController: UITableViewDataSource {
                 notStartedReadingCell.addButtonDidTappedObservable.subscribe { [weak self] isTapped in
                     guard isTapped else { return }
 
-                    self?.pushToAddBookViewController()
+                    self?.configureCreateGoalAlert()
                 }
                 return notStartedReadingCell
             }

--- a/BookTalk/BookTalk/Sources/Presentation/OpenTalk/ViewModel/ChatMenuViewModel.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/OpenTalk/ViewModel/ChatMenuViewModel.swift
@@ -14,12 +14,14 @@ final class ChatMenuViewModel {
     private(set) var completedUsers = Observable<[GoalUserModel]>([])
     private(set) var myProgress = Observable<MyGoalModel?>(nil)
     private(set) var loadState = Observable(LoadState.initial)
+    private(set) var createGoalSucceed = Observable(false)
 
     private var cancellables = Set<AnyCancellable>()
 
     // MARK: - Initializer
 
     let isbn: String
+    var createdGoalId: Int?
 
     init(isbn: String) {
         self.isbn = isbn
@@ -41,30 +43,52 @@ final class ChatMenuViewModel {
 
     enum Action {
         case loadChatMenu(isbn: String)
+        case addGoal(isbn: String, totalPage: String)
     }
 
     func send(action: Action) {
         switch action {
         case let .loadChatMenu(isbn):
-            loadState.value = .loading
+            loadChatMenu(isbn: isbn)
 
+        case let .addGoal(isbn, totalPage):
             Task {
                 do {
-                    let progressingUsers = try await GoalService.getGoalUserState(of: isbn, isFinished: false)
-                    let completedUsers = try await GoalService.getGoalUserState(of: isbn, isFinished: true)
-                    let myProgress = try await GoalService.getMyProgress(of: isbn)
+                    let response = try await GoalService.createGoal(with: isbn, totalPage: Int(totalPage)!)
 
-                    await MainActor.run {
-                        self.progressingUsers.value = progressingUsers
-                        self.completedUsers.value = completedUsers
-                        self.myProgress.value = myProgress
 
-                        loadState.value = .completed
-                    }
+                    NotificationCenter.default.post(name: .goalChanged, object: nil)
+                    createdGoalId = response.goalId
+                    createGoalSucceed.value = true
+
+                    loadChatMenu(isbn: isbn)
+
                 } catch let error as NetworkError {
                     print(error.localizedDescription)
+                }
+            }
+        }
+    }
+
+    private func loadChatMenu(isbn: String) {
+        loadState.value = .loading
+
+        Task {
+            do {
+                let progressingUsers = try await GoalService.getGoalUserState(of: isbn, isFinished: false)
+                let completedUsers = try await GoalService.getGoalUserState(of: isbn, isFinished: true)
+                let myProgress = try await GoalService.getMyProgress(of: isbn)
+
+                await MainActor.run {
+                    self.progressingUsers.value = progressingUsers
+                    self.completedUsers.value = completedUsers
+                    self.myProgress.value = myProgress
+
                     loadState.value = .completed
                 }
+            } catch let error as NetworkError {
+                print(error.localizedDescription)
+                loadState.value = .completed
             }
         }
     }

--- a/BookTalk/BookTalk/Sources/Presentation/OpenTalk/ViewModel/ChatMenuViewModel.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/OpenTalk/ViewModel/ChatMenuViewModel.swift
@@ -52,16 +52,18 @@ final class ChatMenuViewModel {
             loadChatMenu(isbn: isbn)
 
         case let .addGoal(isbn, totalPage):
+
             Task {
                 do {
                     let response = try await GoalService.createGoal(with: isbn, totalPage: Int(totalPage)!)
 
-
-                    NotificationCenter.default.post(name: .goalChanged, object: nil)
-                    createdGoalId = response.goalId
-                    createGoalSucceed.value = true
-
-                    loadChatMenu(isbn: isbn)
+                    await MainActor.run {
+                        createdGoalId = response.goalId
+                        
+                        NotificationCenter.default.post(name: .goalChanged, object: nil)
+                        createGoalSucceed.value = true
+                        loadChatMenu(isbn: isbn)
+                    }
 
                 } catch let error as NetworkError {
                     print(error.localizedDescription)


### PR DESCRIPTION
## 📚 PR 요약
채팅 사이드메뉴뷰에서 목표 생성 시 로직 개선

## 📝 작업 내용
- 목표 생성 버튼 누를 시 페이지 입력 alert 띄우기
- 생성 시 목표상세뷰로 이동

## 📷 Screenshot

<img src = "https://github.com/user-attachments/assets/27be0715-6c14-4fe1-8e8d-64089f39883b" width = 30%>


## 📮 관련 이슈
- Resolved: #186 
