### PR TITLE
[fix] 완료된 목표를 다시 추가하려 할 때 alert 띄우기

### DIFF
--- a/BookTalk/BookTalk/Sources/Presentation/AddBook/View/AddBookViewController.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/AddBook/View/AddBookViewController.swift
@@ -156,6 +156,12 @@ final class AddBookViewController: BaseViewController {
             }
         }
 
+        viewModel.goalExistAlert.subscribe { [weak self] isExist in
+            guard isExist else { return }
+
+            self?.showAutoDismissAlert(title: "이미 완료된 목표로 추가되어 있어요!")
+        }
+
         viewModel.presentAlert.subscribe { [weak self] isPresented in
             guard isPresented else { return }
 

--- a/BookTalk/BookTalk/Sources/Presentation/OpenTalk/View/OpenTalkViewController.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/OpenTalk/View/OpenTalkViewController.swift
@@ -140,37 +140,39 @@ final class OpenTalkViewController: BaseViewController {
     }
 
     private func bind() {
-        viewModel.loadState.subscribe { [weak self] state in
-            guard let self = self else { return }
+        viewModel.loadState.subscribe { state in
+            DispatchQueue.main.async { [weak self] in
+                guard let self = self else { return }
 
-            switch state {
-            case .initial:
-                break
+                switch state {
+                case .initial:
+                    break
 
-            case .loading:
-                indicatorView.startAnimating()
-                bookCollectionView.isHidden = true
+                case .loading:
+                    indicatorView.startAnimating()
+                    bookCollectionView.isHidden = true
 
-            case .completed:
-                indicatorView.stopAnimating()
-                bookCollectionView.isHidden = false
+                case .completed:
+                    indicatorView.stopAnimating()
+                    bookCollectionView.isHidden = false
 
-                var result: [OpenTalkBookModel] = .init()
+                    var result: [OpenTalkBookModel] = .init()
 
-                switch viewModel.selectedPageType {
-                case .hot:
-                    result = viewModel.hotOpenTalks.value
-                case .liked:
-                    result = viewModel.favoriteOpenTalks.value
+                    switch viewModel.selectedPageType {
+                    case .hot:
+                        result = viewModel.hotOpenTalks.value
+                    case .liked:
+                        result = viewModel.favoriteOpenTalks.value
+                    }
+
+                    if result.isEmpty {
+                        bookCollectionView.setEmptyMessage("오픈톡이 없습니다.")
+                    } else {
+                        bookCollectionView.restore()
+                    }
+
+                    bookCollectionView.reloadData()
                 }
-
-                if result.isEmpty {
-                    bookCollectionView.setEmptyMessage("오픈톡이 없습니다.")
-                } else {
-                    bookCollectionView.restore()
-                }
-
-                bookCollectionView.reloadData()
             }
         }
      }


### PR DESCRIPTION
## 📚 PR 요약
완료된 목표를 다시 추가하려 할 때 alert 띄우기

## 📝 작업 내용
- 완료된 목표를 다시 목표로 추가하려 할 때 400, 이미 추가된 목표입니다 라는 에러가 오기 때문에
해당 케이스의 에러에서는 alert를 띄우도록 처리했습니다.

## 📷 Screenshot
<img src = "https://github.com/user-attachments/assets/16621038-3124-4a8a-9ab4-3ebacfff0f3a" width = 30%>

## 📮 관련 이슈
- Resolved: #190 
