### PR TITLE
[feat] 자동 로그인 로직 개선

### DIFF
--- a/BookTalk/BookTalk/Sources/Application/AppFlowController.swift
+++ b/BookTalk/BookTalk/Sources/Application/AppFlowController.swift
@@ -5,7 +5,9 @@
 //  Created by 김민 on 8/20/24.
 //
 
+import AuthenticationServices
 import UIKit
+import KakaoSDKUser
 
 /// 자동 로그인 처리 모듈
 /// 로그인 상태에 따라 초기 화면(로그인, 메인탭)으로 전환
@@ -62,19 +64,58 @@ final class AppFlowController {
     private func goToLogin() {
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
-            
+
             let loginVC = LoginViewController()
             rootViewController = UINavigationController(rootViewController: loginVC)
         }
     }
 
     @objc private func checkLoginState() {
-        let isLogin = UserDefaults.standard.bool(forKey: UserDefaults.Key.isLoggedIn) == true
-
-        if isLogin {
-            goToHome()
-        } else {
+        guard let loginTypeStr = UserDefaults.standard.string(forKey: UserDefaults.Key.loginType),
+              let loginType = LoginType(rawValue: loginTypeStr) else {
             goToLogin()
+            return
+        }
+
+        switch loginType {
+        case .apple:
+            checkAppleAuthState()
+        case .kakao:
+            checkKakaoAuthState()
+        }
+    }
+
+    private func checkAppleAuthState() {
+        let appleIDProvider = ASAuthorizationAppleIDProvider()
+        guard let appleUserId = KeychainManager.shared.read(key: UserKey.appleUserId) else { return }
+
+        appleIDProvider.getCredentialState(forUserID: appleUserId) { [weak self] credentialState, _ in
+            guard let self = self else { return }
+
+            switch credentialState {
+            case .authorized:
+                goToHome()
+            case .revoked, .notFound:
+                goToLogin()
+            default:
+                return
+            }
+        }
+    }
+
+    private func checkKakaoAuthState() {
+        UserApi.shared.accessTokenInfo { [weak self] tokenInfo, error in
+            guard let self = self else { return }
+
+            if let error = error {
+                print("kakao token error: \(error.localizedDescription)")
+                goToLogin()
+            } else if let _ = tokenInfo {
+                goToHome()
+            } else {
+                goToLogin()
+            }
         }
     }
 }
+

--- a/BookTalk/BookTalk/Sources/DTO/User/Response/UserResponseDTO.swift
+++ b/BookTalk/BookTalk/Sources/DTO/User/Response/UserResponseDTO.swift
@@ -30,7 +30,7 @@ struct UserResponseDTO: Decodable {
     let kakaoId: String?
     let appleId: String?
     let regDate: String
-    let nickname: String
+    let nickname: String?
     let gender: String
     let birthDate: String?
     let profileImageUrl: String?
@@ -40,8 +40,8 @@ extension UserResponseDTO {
 
     func toModel() -> UserBasicInfo {
         return .init(
-            profileImage: "", // TODO: 
-            nickname: nickname,
+            profileImage: "", // TODO:
+            nickname: nickname ?? "",
             gender: GenderType(code: gender),
             birth: birthDate
         )

--- a/BookTalk/BookTalk/Sources/Presentation/Login/Enum/LoginType.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Login/Enum/LoginType.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
-enum LoginType {
-    case apple, kakao
+enum LoginType: String {
+    case apple = "apple"
+    case kakao = "kakao"
 }

--- a/BookTalk/BookTalk/Sources/Presentation/Login/View/LoginViewController.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/Login/View/LoginViewController.swift
@@ -99,7 +99,10 @@ final class LoginViewController: BaseViewController {
             guard let self = self else { return }
             guard isLoginCompleted else { return }
 
-            let viewModel = UserInfoViewModel(isInitialEdit: true)
+            let viewModel = UserInfoViewModel(
+                isInitialEdit: true,
+                loginType: viewModel.loginType
+            )
             let registerVC = UserInfoViewController(viewModel: viewModel)
             navigationController?.pushViewController(registerVC, animated: true)
         }

--- a/BookTalk/BookTalk/Sources/Presentation/MyPage/ViewModel/SettingViewModel.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/MyPage/ViewModel/SettingViewModel.swift
@@ -22,9 +22,7 @@ final class SettingViewModel {
                     try await AuthService.logout()
 
                     await MainActor.run {
-                        // TODO: 삭제
-                        UserDefaults.standard.set(false, forKey: UserDefaults.Key.isLoggedIn)
-                        NotificationCenter.default.post(name: .authStateChanged, object: nil)
+                        deleteUserAuthState()
                     }
                 } catch let error as NetworkError {
                     print(error.localizedDescription)
@@ -37,14 +35,17 @@ final class SettingViewModel {
                     try await AuthService.withdraw()
 
                     await MainActor.run {
-                        // TODO: 삭제
-                        UserDefaults.standard.set(false, forKey: UserDefaults.Key.isLoggedIn)
-                        NotificationCenter.default.post(name: .authStateChanged, object: nil)
+                        deleteUserAuthState()
                     }
                 } catch let error as NetworkError {
                     print(error.localizedDescription)
                 }
             }
         }
+    }
+
+    private func deleteUserAuthState() {
+        UserDefaults.standard.set(nil, forKey: UserDefaults.Key.loginType)
+        NotificationCenter.default.post(name: .authStateChanged, object: nil)
     }
 }

--- a/BookTalk/BookTalk/Sources/Util/Extension/Keychain+.swift
+++ b/BookTalk/BookTalk/Sources/Util/Extension/Keychain+.swift
@@ -8,11 +8,16 @@
 import Foundation
 
 typealias TokenKey = KeychainManager.TokenKey
+typealias UserKey = KeychainManager.UserKey
 
 extension KeychainManager {
 
     enum TokenKey {
         static let accessToken = "accessToken"
         static let refreshToken = "refreshToken"
+    }
+
+    enum UserKey {
+        static let appleUserId = "appleUserId"
     }
 }

--- a/BookTalk/BookTalk/Sources/Util/Extension/UserDefaults+.swift
+++ b/BookTalk/BookTalk/Sources/Util/Extension/UserDefaults+.swift
@@ -9,8 +9,9 @@ import Foundation
 
 extension UserDefaults {
 
-    struct Key {
+    enum Key {
         static let isLoggedIn = "isLoggedIn"
         static let userData = "userData"
+        static let loginType = "loginType"
     }
 }


### PR DESCRIPTION
## 📚 PR 요약
자동 로그인 로직 개선

## 📝 작업 내용
- 이전에는 로그인 성공/실패 여부만 `UserDefaults` 에 저장하여 관리
-> 앱 로그아웃 & 탈퇴가 아닌 외부에서 연결을 끊었을 때를 고려하지 못했습니다.

- 따라서 카카오, 애플에서 토큰 유효성을 검증하여 자동 로그인이 되도록했는데, 이 과정에서 `LoginType` 으로 사용자가 어떤 로그인을 했는지는 `UserDefaults` 에 저장하였습니다.
      - 애플 로그인은 애플 로그인 성공 시 받은 `userId` 로 `credentialState`를 사용하여 상태 검증
      - 카카오 로그인은 `accessToken` 을 사용하여 상태 검증

- 로그아웃 & 탈퇴 시에는 `UserDefaults` 에 저장되어 있던 로그인 타입을 `nil`로 처리하고, 해당 값이 `nil` 일 때는 앱 진입 단계에서 로그인창으로 가도록 했습니다.

## 📌 참고 사항
- 따라서 혹시 기존에 애플 로그인으로 가입했을 경우에는 `userId`를 받지 못해서, 우선 앱 삭제 혹은 탈퇴는 불가피할 것 같습니다... 😥

## 📮 관련 이슈
- Resolved: #192 
