### PR TITLE
[refactor] 인증 로직 리팩토링

### DIFF
--- a/BookTalk/BookTalk.xcodeproj/project.pbxproj
+++ b/BookTalk/BookTalk.xcodeproj/project.pbxproj
@@ -150,6 +150,7 @@
 		AB6C19CD2C79A0ED00BF844C /* BookRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB6C19CC2C79A0ED00BF844C /* BookRequestDTO.swift */; };
 		AB6C19D12C79C01C00BF844C /* MyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB6C19D02C79C01C00BF844C /* MyViewModel.swift */; };
 		AB6C19D32C79D3B100BF844C /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB6C19D22C79D3B100BF844C /* String+.swift */; };
+		AB7E267F2C8D7D1F00BBC02B /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB7E267E2C8D7D1F00BBC02B /* AuthManager.swift */; };
 		AB8205552C6E661B0014C5A5 /* GenreTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB8205542C6E661B0014C5A5 /* GenreTarget.swift */; };
 		AB8205572C6E66240014C5A5 /* GenreService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB8205562C6E66240014C5A5 /* GenreService.swift */; };
 		AB82055C2C6E66BD0014C5A5 /* GenreTrendRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB82055B2C6E66BD0014C5A5 /* GenreTrendRequestDTO.swift */; };
@@ -360,6 +361,7 @@
 		AB6C19CC2C79A0ED00BF844C /* BookRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookRequestDTO.swift; sourceTree = "<group>"; };
 		AB6C19D02C79C01C00BF844C /* MyViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyViewModel.swift; sourceTree = "<group>"; };
 		AB6C19D22C79D3B100BF844C /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
+		AB7E267E2C8D7D1F00BBC02B /* AuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthManager.swift; sourceTree = "<group>"; };
 		AB8205542C6E661B0014C5A5 /* GenreTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenreTarget.swift; sourceTree = "<group>"; };
 		AB8205562C6E66240014C5A5 /* GenreService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenreService.swift; sourceTree = "<group>"; };
 		AB82055B2C6E66BD0014C5A5 /* GenreTrendRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = GenreTrendRequestDTO.swift; path = BookTalk/Sources/DTO/Genre/Request/GenreTrendRequestDTO.swift; sourceTree = SOURCE_ROOT; };
@@ -697,6 +699,7 @@
 				AB22AD3D2C4E8D9D00C9A0F3 /* SceneDelegate.swift */,
 				AB949A2E2C7474580005C543 /* AppFlowController.swift */,
 				AB516B5F2C7A052C00168EEF /* UserData.swift */,
+				AB7E267E2C8D7D1F00BBC02B /* AuthManager.swift */,
 			);
 			path = Application;
 			sourceTree = "<group>";
@@ -1774,6 +1777,7 @@
 				AB5D35632C7797050028995C /* LibrariesResponseDTO.swift in Sources */,
 				ABAAFDBB2C76FE9E00FDA084 /* LoadState.swift in Sources */,
 				AB4CBA662C6BB398009A2AB6 /* KeychainManager.swift in Sources */,
+				AB7E267F2C8D7D1F00BBC02B /* AuthManager.swift in Sources */,
 				ABB993602C7F80C900E6DB67 /* CreateGoalRequestDTO.swift in Sources */,
 				ABEF81382C7BD4B1007D1DC7 /* HotTrendResponseDTO.swift in Sources */,
 				051156012C64C6F100230CFE /* BaseTableViewHeaderFooterView.swift in Sources */,

--- a/BookTalk/BookTalk/Sources/Application/AuthManager.swift
+++ b/BookTalk/BookTalk/Sources/Application/AuthManager.swift
@@ -1,0 +1,21 @@
+//
+//  AuthManager.swift
+//  BookTalk
+//
+//  Created by 김민 on 9/8/24.
+//
+
+import Foundation
+
+final class AuthManager {
+    
+    static let shared = AuthManager()
+
+    private init() {}
+
+    func initAuthState() {
+        UserDefaults.standard.set(nil, forKey: UserDefaults.Key.loginType)
+        UserData.shared.deleteUser()
+        KeychainManager.shared.deleteAll()
+    }
+}

--- a/BookTalk/BookTalk/Sources/Application/UserData.swift
+++ b/BookTalk/BookTalk/Sources/Application/UserData.swift
@@ -37,4 +37,11 @@ final class UserData {
             return nil
         }
     }
+
+    func deleteUser() {
+        defaults.removeObject(forKey: key)
+        defaults.synchronize()
+        
+        print("유저 데이터 삭제 완료")
+    }
 }

--- a/BookTalk/BookTalk/Sources/Network/Auth/AuthService.swift
+++ b/BookTalk/BookTalk/Sources/Network/Auth/AuthService.swift
@@ -44,7 +44,7 @@ struct AuthService {
             target: AuthTarget.logout
         )
 
-        KeychainManager.shared.deleteTokens()
+        AuthManager.shared.initAuthState()
     }
 
     static func withdraw() async throws {
@@ -52,7 +52,7 @@ struct AuthService {
             target: AuthTarget.withdraw
         )
 
-        KeychainManager.shared.deleteTokens()
+        AuthManager.shared.initAuthState()
     }
 
     static func reissueToken(with refreshToken: String) async throws {

--- a/BookTalk/BookTalk/Sources/Network/Foundation/Core/NetworkService.swift
+++ b/BookTalk/BookTalk/Sources/Network/Foundation/Core/NetworkService.swift
@@ -9,13 +9,7 @@ import Foundation
 
 import Alamofire
 
-protocol NetworkServiceType {
-    func request<T: Decodable>(
-        target: TargetType
-    ) async throws -> T
-}
-
-final class NetworkService: NetworkServiceType {
+final class NetworkService {
 
     // MARK: - Properties
 

--- a/BookTalk/BookTalk/Sources/Network/Foundation/Core/ServerRequestInterceptor.swift
+++ b/BookTalk/BookTalk/Sources/Network/Foundation/Core/ServerRequestInterceptor.swift
@@ -67,7 +67,8 @@ final class ServerRequestInterceptor: RequestInterceptor {
                 completion(.doNotRetryWithError(error))
                 
                 // 토큰 재발급 불가 시, 로그아웃 처리
-                UserDefaults.standard.set(nil, forKey: UserDefaults.Key.loginType)
+                AuthManager.shared.initAuthState()
+                
                 NotificationCenter.default.post(name: .authStateChanged, object: nil)
             }
         }

--- a/BookTalk/BookTalk/Sources/Presentation/MyPage/ViewModel/SettingViewModel.swift
+++ b/BookTalk/BookTalk/Sources/Presentation/MyPage/ViewModel/SettingViewModel.swift
@@ -22,7 +22,10 @@ final class SettingViewModel {
                     try await AuthService.logout()
 
                     await MainActor.run {
-                        deleteUserAuthState()
+                        NotificationCenter.default.post(
+                            name: .authStateChanged,
+                            object: nil
+                        )
                     }
                 } catch let error as NetworkError {
                     print(error.localizedDescription)
@@ -35,17 +38,15 @@ final class SettingViewModel {
                     try await AuthService.withdraw()
 
                     await MainActor.run {
-                        deleteUserAuthState()
+                        NotificationCenter.default.post(
+                            name: .authStateChanged,
+                            object: nil
+                        )
                     }
                 } catch let error as NetworkError {
                     print(error.localizedDescription)
                 }
             }
         }
-    }
-
-    private func deleteUserAuthState() {
-        UserDefaults.standard.set(nil, forKey: UserDefaults.Key.loginType)
-        NotificationCenter.default.post(name: .authStateChanged, object: nil)
     }
 }

--- a/BookTalk/BookTalk/Sources/Util/Extension/Date+.swift
+++ b/BookTalk/BookTalk/Sources/Util/Extension/Date+.swift
@@ -16,6 +16,7 @@ extension Date {
         var calendar = Calendar.current
         calendar.timeZone = koreaTimeZone
         calendar.firstWeekday = 2
+        calendar.minimumDaysInFirstWeek = 4  
 
         let components = calendar.dateComponents([.year, .month, .weekOfMonth], from: self)
         let month = components.month!

--- a/BookTalk/BookTalk/Sources/Util/Extension/UserDefaults+.swift
+++ b/BookTalk/BookTalk/Sources/Util/Extension/UserDefaults+.swift
@@ -10,7 +10,6 @@ import Foundation
 extension UserDefaults {
 
     enum Key {
-        static let isLoggedIn = "isLoggedIn"
         static let userData = "userData"
         static let loginType = "loginType"
     }

--- a/BookTalk/BookTalk/Sources/Util/KeychainManager.swift
+++ b/BookTalk/BookTalk/Sources/Util/KeychainManager.swift
@@ -58,11 +58,6 @@ final class KeychainManager {
         save(key: TokenKey.refreshToken, token: refreshToken)
     }
 
-    func deleteTokens() {
-        delete(key: TokenKey.accessToken)
-        delete(key: TokenKey.refreshToken)
-    }
-
     func deleteAll() {
         let query: NSDictionary = [
             kSecClass: kSecClassInternetPassword

--- a/BookTalk/BookTalk/Sources/Util/KeychainManager.swift
+++ b/BookTalk/BookTalk/Sources/Util/KeychainManager.swift
@@ -62,5 +62,13 @@ final class KeychainManager {
         delete(key: TokenKey.accessToken)
         delete(key: TokenKey.refreshToken)
     }
+
+    func deleteAll() {
+        let query: NSDictionary = [
+            kSecClass: kSecClassInternetPassword
+        ]
+
+        SecItemDelete(query)
+    }
 }
 


### PR DESCRIPTION
## 📚 PR 요약
인증 로직 리팩토링

## 📝 작업 내용
- 카카오 토큰 유효한 토큰을 발급받은 적이 있을 때만 로그인 여부 체크
- 유저 정보 초기화(appleUserId 삭제, 토큰 삭제, 유저 정보 삭제) 기능을 전체적으로 사용하기 위해 모듈 분리: `AuthManager`
- 로그아웃 / 탈퇴 시 유저 정보 초기화하도록 구현

- 추가적으로 카테코리 부분에서 TOP 10 날짜 오류도 같이 수정했습니다 🙇🏻‍♀️

## 📮 관련 이슈
- Resolved: #199 
